### PR TITLE
New async/await syntax and aioredis 1.0.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
 - docker
 
 python:
-  - 3.4.3
   - 3.5
   - nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
 
 python:
   - 3.5
+  - 3.6
   - nightly
 
 install:

--- a/aiohttp_session/cookie_storage.py
+++ b/aiohttp_session/cookie_storage.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import base64
 
@@ -26,8 +25,7 @@ class EncryptedCookieStorage(AbstractStorage):
             secret_key = base64.urlsafe_b64encode(secret_key)
         self._fernet = fernet.Fernet(secret_key)
 
-    @asyncio.coroutine
-    def load_session(self, request):
+    async def load_session(self, request):
         cookie = self.load_cookie(request)
         if cookie is None:
             return Session(None, data=None, new=True, max_age=self.max_age)
@@ -43,8 +41,7 @@ class EncryptedCookieStorage(AbstractStorage):
                             "create a new fresh session")
                 return Session(None, data=None, new=True, max_age=self.max_age)
 
-    @asyncio.coroutine
-    def save_session(self, request, response, session):
+    async def save_session(self, request, response, session):
         if session.empty:
             return self.save_cookie(response, '',
                                     max_age=session.max_age)

--- a/aiohttp_session/memcached_storage.py
+++ b/aiohttp_session/memcached_storage.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import uuid
 
@@ -21,15 +20,14 @@ class MemcachedStorage(AbstractStorage):
         self._key_factory = key_factory
         self.conn = memcached_conn
 
-    @asyncio.coroutine
-    def load_session(self, request):
+    async def load_session(self, request):
         cookie = self.load_cookie(request)
         if cookie is None:
             return Session(None, data=None, new=True, max_age=self.max_age)
         else:
             key = str(cookie)
             stored_key = (self.cookie_name + '_' + key).encode('utf-8')
-            data = yield from self.conn.get(stored_key)
+            data = await self.conn.get(stored_key)
             if data is None:
                 return Session(None, data=None,
                                new=True, max_age=self.max_age)
@@ -40,8 +38,7 @@ class MemcachedStorage(AbstractStorage):
                 data = None
             return Session(key, data=data, new=False, max_age=self.max_age)
 
-    @asyncio.coroutine
-    def save_session(self, request, response, session):
+    async def save_session(self, request, response, session):
         key = session.identity
         if key is None:
             key = self._key_factory()
@@ -60,6 +57,6 @@ class MemcachedStorage(AbstractStorage):
         max_age = session.max_age
         expire = max_age if max_age is not None else 0
         stored_key = (self.cookie_name + '_' + key).encode('utf-8')
-        yield from self.conn.set(
+        await self.conn.set(
                                 stored_key, data.encode('utf-8'),
                                 exptime=expire)

--- a/aiohttp_session/nacl_storage.py
+++ b/aiohttp_session/nacl_storage.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 
 import nacl.secret
@@ -21,8 +20,7 @@ class NaClCookieStorage(AbstractStorage):
 
         self._secretbox = nacl.secret.SecretBox(secret_key)
 
-    @asyncio.coroutine
-    def load_session(self, request):
+    async def load_session(self, request):
         cookie = self.load_cookie(request)
         if cookie is None:
             return Session(None, data=None, new=True, max_age=self.max_age)
@@ -33,8 +31,7 @@ class NaClCookieStorage(AbstractStorage):
             )
             return Session(None, data=data, new=False, max_age=self.max_age)
 
-    @asyncio.coroutine
-    def save_session(self, request, response, session):
+    async def save_session(self, request, response, session):
         if session.empty:
             return self.save_cookie(response, session._mapping,
                                     max_age=session.max_age)

--- a/aiohttp_session/redis_storage.py
+++ b/aiohttp_session/redis_storage.py
@@ -1,7 +1,11 @@
-import aioredis
+try:
+    import aioredis
+except ImportError:
+    aioredis = None
 import json
 import uuid
 
+from distutils.version import StrictVersion
 from . import AbstractStorage, Session
 
 
@@ -16,6 +20,10 @@ class RedisStorage(AbstractStorage):
         super().__init__(cookie_name=cookie_name, domain=domain,
                          max_age=max_age, path=path, secure=secure,
                          httponly=httponly)
+        if aioredis is None:
+            raise RuntimeError("Please install aioredis")
+        if StrictVersion(aioredis.__version__).version < (1, 0):
+            raise RuntimeError("aioredis<1.0 is not supported")
         self._encoder = encoder
         self._decoder = decoder
         self._key_factory = key_factory

--- a/aiohttp_session/redis_storage.py
+++ b/aiohttp_session/redis_storage.py
@@ -1,6 +1,6 @@
 try:
     import aioredis
-except ImportError:
+except ImportError:  # pragma: no cover
     aioredis = None
 import json
 import uuid

--- a/aiohttp_session/redis_storage.py
+++ b/aiohttp_session/redis_storage.py
@@ -1,4 +1,4 @@
-import asyncio
+import aioredis
 import json
 import uuid
 
@@ -19,17 +19,17 @@ class RedisStorage(AbstractStorage):
         self._encoder = encoder
         self._decoder = decoder
         self._key_factory = key_factory
+        assert isinstance(redis_pool, aioredis.commands.Redis), redis_pool
         self._redis = redis_pool
 
-    @asyncio.coroutine
-    def load_session(self, request):
+    async def load_session(self, request):
         cookie = self.load_cookie(request)
         if cookie is None:
             return Session(None, data=None, new=True, max_age=self.max_age)
         else:
-            with (yield from self._redis) as conn:
+            with await self._redis as conn:
                 key = str(cookie)
-                data = yield from conn.get(self.cookie_name + '_' + key)
+                data = await conn.get(self.cookie_name + '_' + key)
                 if data is None:
                     return Session(None, data=None,
                                    new=True, max_age=self.max_age)
@@ -40,8 +40,7 @@ class RedisStorage(AbstractStorage):
                     data = None
                 return Session(key, data=data, new=False, max_age=self.max_age)
 
-    @asyncio.coroutine
-    def save_session(self, request, response, session):
+    async def save_session(self, request, response, session):
         key = session.identity
         if key is None:
             key = self._key_factory()
@@ -57,8 +56,7 @@ class RedisStorage(AbstractStorage):
                                  max_age=session.max_age)
 
         data = self._encoder(self._get_session_data(session))
-        with (yield from self._redis) as conn:
+        with await self._redis as conn:
             max_age = session.max_age
             expire = max_age if max_age is not None else 0
-            yield from conn.set(self.cookie_name + '_' + key,
-                                data, expire=expire)
+            await conn.set(self.cookie_name + '_' + key, data, expire=expire)

--- a/demo/redis_storage.py
+++ b/demo/redis_storage.py
@@ -17,10 +17,7 @@ async def handler(request):
 
 async def make_redis_pool():
     redis_address = ('127.0.0.1', '6379')
-    return await aioredis.create_pool(
-        redis_address,
-        create_connection_timeout=1,
-    )
+    return await aioredis.create_redis_pool(redis_address, timeout=1)
 
 
 def make_app():

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -115,7 +115,7 @@ Continious Integration.
 Dependencies
 ------------
 
-- Python 3.3 and :mod:`asyncio` or Python 3.4+
+- Python 3.5.3+
 - :term:`cryptography` for
   :class:`~aiohttp_session.cookie_storage.EncryptedCookieStorage`
 - :term:`aioredis` for

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ coverage==4.4.2
 sphinx==1.6.5
 pep257==0.7.0
 -e .
-aioredis==0.3.5
+aioredis==1.0.0
 cryptography==2.1.3
 docker-py==1.10.6
 pynacl==1.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ docker-py==1.10.6
 pynacl==1.2.0
 pytest-aiohttp==0.1.3
 pytest-cov==2.5.1
+pytest-mock==1.6.3
 aiohttp==2.3.2
 multidict==3.3.2
 chardet==3.0.4

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def read(f):
 
 install_requires = ['aiohttp>=2.3.0']
 extras_require = {
-    'aioredis': ['aioredis>=0.1.4, <1.0'],
+    'aioredis': ['aioredis>=1.0.0'],
     'aiomcache': ['aiomcache>=0.5.2'],
     'pycrypto': ['cryptography'],
     'secure': ['cryptography'],
@@ -34,7 +34,6 @@ setup(name='aiohttp-session',
           'Intended Audience :: Developers',
           'Programming Language :: Python',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',
           'Topic :: Internet :: WWW/HTTP',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,19 +81,19 @@ def redis_params(redis_server):
 def redis(loop, redis_params):
     pool = None
 
-    @asyncio.coroutine
-    def start(*args, no_loop=False, **kwargs):
+    async def start(*args, no_loop=False, **kwargs):
         nonlocal pool
         params = redis_params.copy()
         params.update(kwargs)
         useloop = None if no_loop else loop
-        pool = yield from aioredis.create_pool(loop=useloop, **params)
+        pool = await aioredis.create_redis_pool(loop=useloop, **params)
         return pool
 
     loop.run_until_complete(start())
     yield pool
     if pool is not None:
-        loop.run_until_complete(pool.clear())
+        pool.close()
+        loop.run_until_complete(pool.wait_closed())
 
 
 @pytest.fixture(scope='session')

--- a/tests/test_abstract_storage.py
+++ b/tests/test_abstract_storage.py
@@ -1,4 +1,3 @@
-import asyncio
 from unittest import mock
 import json
 import time
@@ -25,22 +24,20 @@ def create_app(loop, handler):
     return app
 
 
-@asyncio.coroutine
-def test_max_age_also_returns_expires(test_client):
+async def test_max_age_also_returns_expires(test_client):
 
-    @asyncio.coroutine
-    def handler(request):
+    async def handler(request):
         time.time.return_value = 0.0
-        session = yield from get_session(request)
+        session = await get_session(request)
         session['c'] = 3
         return web.Response(body=b'OK')
 
     with mock.patch('time.time') as m_clock:
         m_clock.return_value = 0.0
 
-        client = yield from test_client(create_app, handler)
+        client = await test_client(create_app, handler)
         make_cookie(client, {'a': 1, 'b': 2})
-        resp = yield from client.get('/')
+        resp = await client.get('/')
         assert resp.status == 200
         assert 'expires=Thu, 01-Jan-1970 00:00:10 GMT' in \
                resp.headers['SET-COOKIE']

--- a/tests/test_get_session.py
+++ b/tests/test_get_session.py
@@ -1,4 +1,3 @@
-import asyncio
 import pytest
 
 from aiohttp.test_utils import make_mocked_request
@@ -6,19 +5,17 @@ from aiohttp.test_utils import make_mocked_request
 from aiohttp_session import Session, get_session, SESSION_KEY
 
 
-@asyncio.coroutine
-def test_get_stored_session():
+async def test_get_stored_session():
     req = make_mocked_request('GET', '/')
     session = Session('identity', data=None, new=False)
     req[SESSION_KEY] = session
 
-    ret = yield from get_session(req)
+    ret = await get_session(req)
     assert session is ret
 
 
-@asyncio.coroutine
-def test_session_is_not_stored():
+async def test_session_is_not_stored():
     req = make_mocked_request('GET', '/')
 
     with pytest.raises(RuntimeError):
-        yield from get_session(req)
+        await get_session(req)

--- a/tests/test_http_exception.py
+++ b/tests/test_http_exception.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from aiohttp import web
 from aiohttp_session import (session_middleware,
                              get_session, SimpleCookieStorage)
@@ -13,27 +11,22 @@ def create_app(loop, *handlers):
     return app
 
 
-@asyncio.coroutine
-def test_exceptions(test_client):
+async def test_exceptions(test_client):
 
-    @asyncio.coroutine
-    def save(request):
-        session = yield from get_session(request)
+    async def save(request):
+        session = await get_session(request)
         session['message'] = 'works'
         raise web.HTTPFound('/show')
 
-    @asyncio.coroutine
-    def show(request):
-        session = yield from get_session(request)
+    async def show(request):
+        session = await get_session(request)
         message = session.get('message')
         return web.Response(text=str(message))
 
-    client = yield from test_client(create_app,
-                                    ('/save', save),
-                                    ('/show', show))
+    client = await test_client(create_app, ('/save', save), ('/show', show))
 
-    resp = yield from client.get('/save')
+    resp = await client.get('/save')
     assert resp.status == 200
     assert str(resp.url)[-5:] == '/show'
-    text = yield from resp.text()
+    text = await resp.text()
     assert text == 'works'

--- a/tests/test_memcached_storage.py
+++ b/tests/test_memcached_storage.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import uuid
 import time
@@ -17,8 +16,7 @@ def create_app(loop, handler, memcached, max_age=None,
     return app
 
 
-@asyncio.coroutine
-def make_cookie(client, memcached, data):
+async def make_cookie(client, memcached, data):
     session_data = {
         'session': data,
         'created': int(time.time())
@@ -26,96 +24,87 @@ def make_cookie(client, memcached, data):
     value = json.dumps(session_data)
     key = uuid.uuid4().hex
     storage_key = ('AIOHTTP_SESSION_' + key).encode('utf-8')
-    yield from memcached.set(storage_key, bytes(value, 'utf-8'))
+    await memcached.set(storage_key, bytes(value, 'utf-8'))
     client.session.cookie_jar.update_cookies({'AIOHTTP_SESSION': key})
 
 
-@asyncio.coroutine
-def make_cookie_with_bad_value(client, memcached):
+async def make_cookie_with_bad_value(client, memcached):
     key = uuid.uuid4().hex
     storage_key = ('AIOHTTP_SESSION_' + key).encode('utf-8')
-    yield from memcached.set(storage_key, b'')
+    await memcached.set(storage_key, b'')
     client.session.cookie_jar.update_cookies({'AIOHTTP_SESSION': key})
 
 
-@asyncio.coroutine
-def load_cookie(client, memcached):
+async def load_cookie(client, memcached):
     cookies = client.session.cookie_jar.filter_cookies(client.make_url('/'))
     key = cookies['AIOHTTP_SESSION']
     storage_key = ('AIOHTTP_SESSION_' + key.value).encode('utf-8')
-    encoded = yield from memcached.get(storage_key)
+    encoded = await memcached.get(storage_key)
     s = encoded.decode('utf-8')
     value = json.loads(s)
     return value
 
 
-@asyncio.coroutine
-def test_create_new_sesssion(test_client, memcached):
+async def test_create_new_sesssion(test_client, memcached):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         assert isinstance(session, Session)
         assert session.new
         assert not session._changed
         assert {} == session
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler, memcached)
-    resp = yield from client.get('/')
+    client = await test_client(create_app, handler, memcached)
+    resp = await client.get('/')
     assert resp.status == 200
 
 
-@asyncio.coroutine
-def test_load_existing_sesssion(test_client, memcached):
+async def test_load_existing_sesssion(test_client, memcached):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         assert isinstance(session, Session)
         assert not session.new
         assert not session._changed
         assert {'a': 1, 'b': 12} == session
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler, memcached)
-    yield from make_cookie(client, memcached, {'a': 1, 'b': 12})
-    resp = yield from client.get('/')
+    client = await test_client(create_app, handler, memcached)
+    await make_cookie(client, memcached, {'a': 1, 'b': 12})
+    resp = await client.get('/')
     assert resp.status == 200
 
 
-@asyncio.coroutine
-def test_load_bad_sesssion(test_client, memcached):
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+async def test_load_bad_sesssion(test_client, memcached):
+
+    async def handler(request):
+        session = await get_session(request)
         assert isinstance(session, Session)
         assert not session.new
         assert not session._changed
         assert {} == session
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler, memcached)
-    yield from make_cookie_with_bad_value(client, memcached)
-    resp = yield from client.get('/')
+    client = await test_client(create_app, handler, memcached)
+    await make_cookie_with_bad_value(client, memcached)
+    resp = await client.get('/')
     assert resp.status == 200
 
 
-@asyncio.coroutine
-def test_change_sesssion(test_client, memcached):
+async def test_change_sesssion(test_client, memcached):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         session['c'] = 3
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler, memcached)
-    yield from make_cookie(client, memcached, {'a': 1, 'b': 2})
-    resp = yield from client.get('/')
+    client = await test_client(create_app, handler, memcached)
+    await make_cookie(client, memcached, {'a': 1, 'b': 2})
+    resp = await client.get('/')
     assert resp.status == 200
 
-    value = yield from load_cookie(client, memcached)
+    value = await load_cookie(client, memcached)
     assert 'session' in value
     assert 'a' in value['session']
     assert 'b' in value['session']
@@ -129,21 +118,19 @@ def test_change_sesssion(test_client, memcached):
     assert '/' == morsel['path']
 
 
-@asyncio.coroutine
-def test_clear_cookie_on_sesssion_invalidation(test_client, memcached):
+async def test_clear_cookie_on_sesssion_invalidation(test_client, memcached):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         session.invalidate()
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler, memcached)
-    yield from make_cookie(client, memcached, {'a': 1, 'b': 2})
-    resp = yield from client.get('/')
+    client = await test_client(create_app, handler, memcached)
+    await make_cookie(client, memcached, {'a': 1, 'b': 2})
+    resp = await client.get('/')
     assert resp.status == 200
 
-    value = yield from load_cookie(client, memcached)
+    value = await load_cookie(client, memcached)
     assert {} == value
     morsel = resp.cookies['AIOHTTP_SESSION']
     assert morsel['path'] == '/'
@@ -151,21 +138,19 @@ def test_clear_cookie_on_sesssion_invalidation(test_client, memcached):
     assert morsel['max-age'] == "0"
 
 
-@asyncio.coroutine
-def test_create_cookie_in_handler(test_client, memcached):
+async def test_create_cookie_in_handler(test_client, memcached):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         session['a'] = 1
         session['b'] = 2
         return web.Response(body=b'OK', headers={'HOST': 'example.com'})
 
-    client = yield from test_client(create_app, handler, memcached)
-    resp = yield from client.get('/')
+    client = await test_client(create_app, handler, memcached)
+    resp = await client.get('/')
     assert resp.status == 200
 
-    value = yield from load_cookie(client, memcached)
+    value = await load_cookie(client, memcached)
     assert 'session' in value
     assert 'a' in value['session']
     assert 'b' in value['session']
@@ -176,33 +161,29 @@ def test_create_cookie_in_handler(test_client, memcached):
     assert morsel['httponly']
     assert morsel['path'] == '/'
     storage_key = ('AIOHTTP_SESSION_' + morsel.value).encode('utf-8')
-    exists = yield from memcached.get(storage_key)
+    exists = await memcached.get(storage_key)
     assert exists
 
 
-@asyncio.coroutine
-def test_create_new_sesssion_if_key_doesnt_exists_in_memcached(
+async def test_create_new_sesssion_if_key_doesnt_exists_in_memcached(
         test_client, memcached):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         assert session.new
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler, memcached)
+    client = await test_client(create_app, handler, memcached)
     client.session.cookie_jar.update_cookies(
         {'AIOHTTP_SESSION': 'invalid_key'})
-    resp = yield from client.get('/')
+    resp = await client.get('/')
     assert resp.status == 200
 
 
-@asyncio.coroutine
-def test_create_storate_with_custom_key_factory(test_client, memcached):
+async def test_create_storate_with_custom_key_factory(test_client, memcached):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         session['key'] = 'value'
         assert session.new
         return web.Response(body=b'OK')
@@ -210,13 +191,12 @@ def test_create_storate_with_custom_key_factory(test_client, memcached):
     def key_factory():
         return 'test-key'
 
-    client = yield from test_client(create_app, handler, memcached, 8,
-                                    key_factory)
-    resp = yield from client.get('/')
+    client = await test_client(create_app, handler, memcached, 8, key_factory)
+    resp = await client.get('/')
     assert resp.status == 200
 
     assert resp.cookies['AIOHTTP_SESSION'].value == 'test-key'
 
-    value = yield from load_cookie(client, memcached)
+    value = await load_cookie(client, memcached)
     assert 'key' in value['session']
     assert value['session']['key'] == 'value'

--- a/tests/test_path_domain.py
+++ b/tests/test_path_domain.py
@@ -1,4 +1,3 @@
-import asyncio
 from http import cookies
 import json
 import time
@@ -33,19 +32,17 @@ def create_app(loop, handler, path=None, domain=None):
     return app
 
 
-@asyncio.coroutine
-def test_with_same_path_domain(test_client):
+async def test_with_same_path_domain(test_client):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         session['c'] = 3
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler)
+    client = await test_client(create_app, handler)
     make_cookie(client, {'a': 1, 'b': 2},
                 path="/anotherpath", domain="127.0.0.1")
-    resp = yield from client.get('/anotherpath')
+    resp = await client.get('/anotherpath')
     assert resp.status == 200
     morsel = resp.cookies['AIOHTTP_SESSION']
     cookie_data = json.loads(morsel.value)
@@ -62,19 +59,17 @@ def test_with_same_path_domain(test_client):
     assert '127.0.0.1' == morsel['domain']
 
 
-@asyncio.coroutine
-def test_with_different_path(test_client):
+async def test_with_different_path(test_client):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         session['c'] = 3
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler)
+    client = await test_client(create_app, handler)
     make_cookie(client, {'a': 1, 'b': 2},
                 path="/NotTheSame", domain="127.0.0.1")
-    resp = yield from client.get('/anotherpath')
+    resp = await client.get('/anotherpath')
     assert resp.status == 200
     morsel = resp.cookies['AIOHTTP_SESSION']
     cookie_data = json.loads(morsel.value)
@@ -89,19 +84,17 @@ def test_with_different_path(test_client):
     assert '127.0.0.1' == morsel['domain']
 
 
-@asyncio.coroutine
-def test_with_different_domain(test_client):
+async def test_with_different_domain(test_client):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         session['c'] = 3
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler)
+    client = await test_client(create_app, handler)
     make_cookie(client, {'a': 1, 'b': 2},
                 path="/anotherpath", domain="localhost")
-    resp = yield from client.get('/anotherpath')
+    resp = await client.get('/anotherpath')
     assert resp.status == 200
     morsel = resp.cookies['AIOHTTP_SESSION']
     cookie_data = json.loads(morsel.value)
@@ -116,20 +109,18 @@ def test_with_different_domain(test_client):
     assert '127.0.0.1' == morsel['domain']
 
 
-@asyncio.coroutine
-def test_invalidate_with_same_path_domain(test_client):
+async def test_invalidate_with_same_path_domain(test_client):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         session.invalidate()
 
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler)
+    client = await test_client(create_app, handler)
     make_cookie(client, {'a': 1, 'b': 2},
                 path="/anotherpath", domain="127.0.0.1")
-    resp = yield from client.get('/anotherpath')
+    resp = await client.get('/anotherpath')
     assert resp.status == 200
     morsel = resp.cookies['AIOHTTP_SESSION']
     cookie_data = json.loads(morsel.value)

--- a/tests/test_redis_storage.py
+++ b/tests/test_redis_storage.py
@@ -1,4 +1,6 @@
+import aioredis
 import json
+import pytest
 import uuid
 import time
 
@@ -241,3 +243,22 @@ async def test_create_storate_with_custom_key_factory(test_client, redis):
     value = await load_cookie(client, redis)
     assert 'key' in value['session']
     assert value['session']['key'] == 'value'
+
+
+async def test_redis_from_create_pool(loop, redis_params):
+
+    async def handler(request):
+        pass
+
+    redis = await aioredis.create_pool(loop=loop, **redis_params)
+    with pytest.warns(DeprecationWarning):
+        create_app(loop=loop, handler=handler, redis=redis)
+
+
+async def test_not_redis_provided_to_storage(loop):
+
+    async def handler(request):
+        pass
+
+    with pytest.raises(TypeError):
+        create_app(loop=loop, handler=handler, redis=None)

--- a/tests/test_redis_storage.py
+++ b/tests/test_redis_storage.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import uuid
 import time
@@ -17,105 +16,95 @@ def create_app(loop, handler, redis, max_age=None,
     return app
 
 
-@asyncio.coroutine
-def make_cookie(client, redis, data):
+async def make_cookie(client, redis, data):
     session_data = {
         'session': data,
         'created': int(time.time())
     }
     value = json.dumps(session_data)
     key = uuid.uuid4().hex
-    with (yield from redis) as conn:
-        yield from conn.set('AIOHTTP_SESSION_' + key, value)
+    with await redis as conn:
+        await conn.set('AIOHTTP_SESSION_' + key, value)
     client.session.cookie_jar.update_cookies({'AIOHTTP_SESSION': key})
 
 
-@asyncio.coroutine
-def make_cookie_with_bad_value(client, redis):
+async def make_cookie_with_bad_value(client, redis):
     key = uuid.uuid4().hex
-    with (yield from redis) as conn:
-        yield from conn.set('AIOHTTP_SESSION_' + key, '')
+    with await redis as conn:
+        await conn.set('AIOHTTP_SESSION_' + key, '')
     client.session.cookie_jar.update_cookies({'AIOHTTP_SESSION': key})
 
 
-@asyncio.coroutine
-def load_cookie(client, redis):
+async def load_cookie(client, redis):
     cookies = client.session.cookie_jar.filter_cookies(client.make_url('/'))
     key = cookies['AIOHTTP_SESSION']
-    with (yield from redis) as conn:
-        encoded = yield from conn.get('AIOHTTP_SESSION_' + key.value)
+    with await redis as conn:
+        encoded = await conn.get('AIOHTTP_SESSION_' + key.value)
         s = encoded.decode('utf-8')
         value = json.loads(s)
         return value
 
 
-@asyncio.coroutine
-def test_create_new_sesssion(test_client, redis):
+async def test_create_new_sesssion(test_client, redis):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         assert isinstance(session, Session)
         assert session.new
         assert not session._changed
         assert {} == session
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler, redis)
-    resp = yield from client.get('/')
+    client = await test_client(create_app, handler, redis)
+    resp = await client.get('/')
     assert resp.status == 200
 
 
-@asyncio.coroutine
-def test_load_existing_sesssion(test_client, redis):
+async def test_load_existing_sesssion(test_client, redis):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         assert isinstance(session, Session)
         assert not session.new
         assert not session._changed
         assert {'a': 1, 'b': 12} == session
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler, redis)
-    yield from make_cookie(client, redis, {'a': 1, 'b': 12})
-    resp = yield from client.get('/')
+    client = await test_client(create_app, handler, redis)
+    await make_cookie(client, redis, {'a': 1, 'b': 12})
+    resp = await client.get('/')
     assert resp.status == 200
 
 
-@asyncio.coroutine
-def test_load_bad_sesssion(test_client, redis):
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+async def test_load_bad_sesssion(test_client, redis):
+
+    async def handler(request):
+        session = await get_session(request)
         assert isinstance(session, Session)
         assert not session.new
         assert not session._changed
         assert {} == session
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler, redis)
-    yield from make_cookie_with_bad_value(client, redis)
-    resp = yield from client.get('/')
+    client = await test_client(create_app, handler, redis)
+    await make_cookie_with_bad_value(client, redis)
+    resp = await client.get('/')
     assert resp.status == 200
 
 
-@asyncio.coroutine
-def test_change_sesssion(test_client, redis):
+async def test_change_sesssion(test_client, redis):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         session['c'] = 3
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler, redis)
-    yield from make_cookie(client, redis, {'a': 1, 'b': 2})
-    resp = yield from client.get('/')
+    client = await test_client(create_app, handler, redis)
+    await make_cookie(client, redis, {'a': 1, 'b': 2})
+    resp = await client.get('/')
     assert resp.status == 200
 
-    value = yield from load_cookie(client, redis)
+    value = await load_cookie(client, redis)
     assert 'session' in value
     assert 'a' in value['session']
     assert 'b' in value['session']
@@ -129,21 +118,19 @@ def test_change_sesssion(test_client, redis):
     assert '/' == morsel['path']
 
 
-@asyncio.coroutine
-def test_clear_cookie_on_sesssion_invalidation(test_client, redis):
+async def test_clear_cookie_on_sesssion_invalidation(test_client, redis):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         session.invalidate()
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler, redis)
-    yield from make_cookie(client, redis, {'a': 1, 'b': 2})
-    resp = yield from client.get('/')
+    client = await test_client(create_app, handler, redis)
+    await make_cookie(client, redis, {'a': 1, 'b': 2})
+    resp = await client.get('/')
     assert resp.status == 200
 
-    value = yield from load_cookie(client, redis)
+    value = await load_cookie(client, redis)
     assert {} == value
     morsel = resp.cookies['AIOHTTP_SESSION']
     assert morsel['path'] == '/'
@@ -151,21 +138,19 @@ def test_clear_cookie_on_sesssion_invalidation(test_client, redis):
     assert morsel['max-age'] == "0"
 
 
-@asyncio.coroutine
-def test_create_cookie_in_handler(test_client, redis):
+async def test_create_cookie_in_handler(test_client, redis):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         session['a'] = 1
         session['b'] = 2
         return web.Response(body=b'OK', headers={'HOST': 'example.com'})
 
-    client = yield from test_client(create_app, handler, redis)
-    resp = yield from client.get('/')
+    client = await test_client(create_app, handler, redis)
+    resp = await client.get('/')
     assert resp.status == 200
 
-    value = yield from load_cookie(client, redis)
+    value = await load_cookie(client, redis)
     assert 'session' in value
     assert 'a' in value['session']
     assert 'b' in value['session']
@@ -175,79 +160,71 @@ def test_create_cookie_in_handler(test_client, redis):
     morsel = resp.cookies['AIOHTTP_SESSION']
     assert morsel['httponly']
     assert morsel['path'] == '/'
-    with (yield from redis) as conn:
-        exists = yield from conn.exists('AIOHTTP_SESSION_' +
-                                        morsel.value)
+    with await redis as conn:
+        exists = await conn.exists('AIOHTTP_SESSION_' + morsel.value)
         assert exists
 
 
-@asyncio.coroutine
-def test_set_ttl_on_session_saving(test_client, redis):
+async def test_set_ttl_on_session_saving(test_client, redis):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         session['a'] = 1
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler, redis, max_age=10)
-    resp = yield from client.get('/')
+    client = await test_client(create_app, handler, redis, max_age=10)
+    resp = await client.get('/')
     assert resp.status == 200
 
     key = resp.cookies['AIOHTTP_SESSION'].value
 
-    with (yield from redis) as conn:
-        ttl = yield from conn.ttl('AIOHTTP_SESSION_'+key)
+    with await redis as conn:
+        ttl = await conn.ttl('AIOHTTP_SESSION_'+key)
 
     assert ttl > 9
     assert ttl <= 10
 
 
-@asyncio.coroutine
-def test_set_ttl_manually_set(test_client, redis):
+async def test_set_ttl_manually_set(test_client, redis):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         session.max_age = 10
         session['a'] = 1
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler, redis)
-    resp = yield from client.get('/')
+    client = await test_client(create_app, handler, redis)
+    resp = await client.get('/')
     assert resp.status == 200
 
     key = resp.cookies['AIOHTTP_SESSION'].value
 
-    with (yield from redis) as conn:
-        ttl = yield from conn.ttl('AIOHTTP_SESSION_'+key)
+    with await redis as conn:
+        ttl = await conn.ttl('AIOHTTP_SESSION_'+key)
 
     assert ttl > 9
     assert ttl <= 10
 
 
-@asyncio.coroutine
-def test_create_new_sesssion_if_key_doesnt_exists_in_redis(test_client, redis):
+async def test_create_new_sesssion_if_key_doesnt_exists_in_redis(test_client,
+                                                                 redis):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         assert session.new
         return web.Response(body=b'OK')
 
-    client = yield from test_client(create_app, handler, redis)
+    client = await test_client(create_app, handler, redis)
     client.session.cookie_jar.update_cookies(
         {'AIOHTTP_SESSION': 'invalid_key'})
-    resp = yield from client.get('/')
+    resp = await client.get('/')
     assert resp.status == 200
 
 
-@asyncio.coroutine
-def test_create_storate_with_custom_key_factory(test_client, redis):
+async def test_create_storate_with_custom_key_factory(test_client, redis):
 
-    @asyncio.coroutine
-    def handler(request):
-        session = yield from get_session(request)
+    async def handler(request):
+        session = await get_session(request)
         session['key'] = 'value'
         assert session.new
         return web.Response(body=b'OK')
@@ -255,12 +232,12 @@ def test_create_storate_with_custom_key_factory(test_client, redis):
     def key_factory():
         return 'test-key'
 
-    client = yield from test_client(create_app, handler, redis, 8, key_factory)
-    resp = yield from client.get('/')
+    client = await test_client(create_app, handler, redis, 8, key_factory)
+    resp = await client.get('/')
     assert resp.status == 200
 
     assert resp.cookies['AIOHTTP_SESSION'].value == 'test-key'
 
-    value = yield from load_cookie(client, redis)
+    value = await load_cookie(client, redis)
     assert 'key' in value['session']
     assert value['session']['key'] == 'value'

--- a/tests/test_redis_storage.py
+++ b/tests/test_redis_storage.py
@@ -262,3 +262,27 @@ async def test_not_redis_provided_to_storage(loop):
 
     with pytest.raises(TypeError):
         create_app(loop=loop, handler=handler, redis=None)
+
+
+async def test_no_aioredis_installed(loop, mocker):
+
+    async def handler(request):
+        pass
+
+    mocker.patch('aiohttp_session.redis_storage.aioredis', None)
+    with pytest.raises(RuntimeError):
+        create_app(loop=loop, handler=handler, redis=None)
+
+
+async def test_old_aioredis_version(loop, mocker):
+
+    async def handler(request):
+        pass
+
+    class Dummy(object):
+        def __init__(self, *args, **kwargs):
+            self.version = (0, 3)
+
+    mocker.patch('aiohttp_session.redis_storage.StrictVersion', Dummy)
+    with pytest.raises(RuntimeError):
+        create_app(loop=loop, handler=handler, redis=None)

--- a/tests/test_response_types.py
+++ b/tests/test_response_types.py
@@ -1,4 +1,3 @@
-import asyncio
 import pytest
 
 from aiohttp import web
@@ -15,46 +14,39 @@ def create_app(loop, *handlers):
     return app
 
 
-@asyncio.coroutine
-def test_stream_response(test_client):
+async def test_stream_response(test_client):
 
-    @asyncio.coroutine
-    def stream_response(request):
-        session = yield from get_session(request)
+    async def stream_response(request):
+        session = await get_session(request)
         session['will_not'] = 'show up'
         return web.StreamResponse()
 
-    client = yield from test_client(create_app,
-                                    ('/stream', stream_response))
+    client = await test_client(create_app, ('/stream', stream_response))
 
-    resp = yield from client.get('/stream')
+    resp = await client.get('/stream')
     assert resp.status == 200
     assert SESSION_KEY.upper() not in resp.cookies
 
 
-@asyncio.coroutine
-def test_bad_response_type(test_client):
+async def test_bad_response_type(test_client):
 
-    @asyncio.coroutine
-    def bad_response(request):
+    async def bad_response(request):
         return ''
 
     middleware = session_middleware(SimpleCookieStorage())
     req = make_mocked_request('GET', '/')
     with pytest.raises(RuntimeError):
-        yield from middleware(req, bad_response)
+        await middleware(req, bad_response)
 
 
-@asyncio.coroutine
-def test_prepared_response_type(test_client):
+async def test_prepared_response_type(test_client):
 
-    @asyncio.coroutine
-    def prepared_response(request):
+    async def prepared_response(request):
         resp = web.Response()
-        yield from resp.prepare(request)
+        await resp.prepare(request)
         return resp
 
     middleware = session_middleware(SimpleCookieStorage())
     req = make_mocked_request('GET', '/')
     with pytest.raises(RuntimeError):
-        yield from middleware(req, prepared_response)
+        await middleware(req, prepared_response)


### PR DESCRIPTION
Drops support for Python<3.5.3
Drops support for aioredis<1.0.0

Caveats:
* The reason support for aioredis<1.0.0 was dropped:
  * create_pool returns a `ConnectionsPool` object
  * when `ConnectionsPool` is used with context management returns a `RedisConnection` object
  * `RedisConnection` doesn't have `set` / `get` methods in v1.0.0+
  * create_redis_pool (introduced in v1.0.0 ) returns a `Redis` object that wrapps `ConnectionsPool`
  * when `Redis` is used whith context management returns a `ContextRedis` object that has `set` / `get`

My initial idea was to check whether the supplied pool was `ConnectionsPool` or `Redis` and in the first case wrap it:
```py
if isinstance(redis_pool, aioredis.pool.ConnectionsPool):
    redis_pool = aioredis.commands.Redis(redis_pool)
elif not isinstance(redis_pool, aioredis.commands.Redis):
    raise something
```

But I was not sure about it. If you prefer the above over straight up asserting that `redis_pool` is instance of `Redis` I can add it.

Finally there is the issue that users of `aiohttp-session` will now have to generate the redis_pool that they provide to `RedisStorage` using `create_redis_pool` instead of `create_pool` and I'm not sure what the best approach to communicate this to them would be.