### PR TITLE
Fixed the formatting of an error handling bad middleware return types.

### DIFF
--- a/aiohttp_session/__init__.py
+++ b/aiohttp_session/__init__.py
@@ -134,7 +134,8 @@ def session_middleware(storage):
             response = exc
             raise_response = True
         if not isinstance(response, web.StreamResponse):
-            raise RuntimeError("Expect response, not {!r}", type(response))
+            raise RuntimeError(
+                "Expect response, not {!r}".format(type(response)))
         if not isinstance(response, web.Response):
             # likely got websoket or streaming
             return response


### PR DESCRIPTION
Found when I was trying to add session data to home-assistant.




Mildly related to https://github.com/home-assistant/home-assistant/pull/12078.