### PR TITLE
Added the minimum python version into setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(name='aiohttp-session',
       url='https://github.com/aio-libs/aiohttp_session/',
       license='Apache 2',
       packages=['aiohttp_session'],
+      python_requires=">=3.5",
       install_requires=install_requires,
       include_package_data=True,
       extras_require=extras_require)


### PR DESCRIPTION
I was just testing a change to a library using aiohttp-session and realised that I was able to install aiohttp-session v2 into a python3.4 environment.

Adding the python_requires metadata prevents this from happening.


See also:
 * https://stackoverflow.com/a/45362425/741316
 * http://www.python3statement.org/practicalities/
 * The docs at http://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords