### PR TITLE
Move encoder and decoder to AbstractStorage

### DIFF
--- a/aiohttp_session/__init__.py
+++ b/aiohttp_session/__init__.py
@@ -8,7 +8,7 @@ import time
 from aiohttp import web
 
 
-__version__ = '2.2.0'
+__version__ = '2.3.0'
 
 
 class Session(MutableMapping):

--- a/aiohttp_session/cookie_storage.py
+++ b/aiohttp_session/cookie_storage.py
@@ -33,7 +33,7 @@ class EncryptedCookieStorage(AbstractStorage):
             return Session(None, data=None, new=True, max_age=self.max_age)
         else:
             try:
-                data = json.loads(
+                data = self._decoder(
                     self._fernet.decrypt(
                         cookie.encode('utf-8')).decode('utf-8'))
                 return Session(None, data=data,
@@ -48,7 +48,7 @@ class EncryptedCookieStorage(AbstractStorage):
             return self.save_cookie(response, '',
                                     max_age=session.max_age)
 
-        cookie_data = json.dumps(
+        cookie_data = self._encoder(
             self._get_session_data(session)
         ).encode('utf-8')
         self.save_cookie(

--- a/aiohttp_session/cookie_storage.py
+++ b/aiohttp_session/cookie_storage.py
@@ -14,10 +14,12 @@ class EncryptedCookieStorage(AbstractStorage):
 
     def __init__(self, secret_key, *, cookie_name="AIOHTTP_SESSION",
                  domain=None, max_age=None, path='/',
-                 secure=None, httponly=True):
+                 secure=None, httponly=True,
+                 encoder=json.dumps, decoder=json.loads):
         super().__init__(cookie_name=cookie_name, domain=domain,
                          max_age=max_age, path=path, secure=secure,
-                         httponly=httponly)
+                         httponly=httponly,
+                         encoder=encoder, decoder=decoder)
 
         if isinstance(secret_key, str):
             pass

--- a/aiohttp_session/memcached_storage.py
+++ b/aiohttp_session/memcached_storage.py
@@ -1,6 +1,5 @@
-import json
 import uuid
-
+import json
 from . import AbstractStorage, Session
 
 
@@ -10,13 +9,12 @@ class MemcachedStorage(AbstractStorage):
     def __init__(self, memcached_conn, *, cookie_name="AIOHTTP_SESSION",
                  domain=None, max_age=None, path='/',
                  secure=None, httponly=True,
-                 encoder=json.dumps, decoder=json.loads,
-                 key_factory=lambda: uuid.uuid4().hex):
+                 key_factory=lambda: uuid.uuid4().hex,
+                 encoder=json.dumps, decoder=json.loads):
         super().__init__(cookie_name=cookie_name, domain=domain,
                          max_age=max_age, path=path, secure=secure,
-                         httponly=httponly)
-        self._encoder = encoder
-        self._decoder = decoder
+                         httponly=httponly,
+                         encoder=encoder, decoder=decoder)
         self._key_factory = key_factory
         self.conn = memcached_conn
 

--- a/aiohttp_session/nacl_storage.py
+++ b/aiohttp_session/nacl_storage.py
@@ -13,10 +13,12 @@ class NaClCookieStorage(AbstractStorage):
 
     def __init__(self, secret_key, *, cookie_name="AIOHTTP_SESSION",
                  domain=None, max_age=None, path='/',
-                 secure=None, httponly=True):
+                 secure=None, httponly=True,
+                 encoder=json.dumps, decoder=json.loads):
         super().__init__(cookie_name=cookie_name, domain=domain,
                          max_age=max_age, path=path, secure=secure,
-                         httponly=httponly)
+                         httponly=httponly,
+                         encoder=encoder, decoder=decoder)
 
         self._secretbox = nacl.secret.SecretBox(secret_key)
 
@@ -25,7 +27,7 @@ class NaClCookieStorage(AbstractStorage):
         if cookie is None:
             return Session(None, data=None, new=True, max_age=self.max_age)
         else:
-            data = json.loads(
+            data = self._decoder(
                 self._secretbox.decrypt(cookie.encode('utf-8'),
                                         encoder=Base64Encoder).decode('utf-8')
             )
@@ -36,7 +38,7 @@ class NaClCookieStorage(AbstractStorage):
             return self.save_cookie(response, session._mapping,
                                     max_age=session.max_age)
 
-        cookie_data = json.dumps(
+        cookie_data = self._encoder(
             self._get_session_data(session)
         ).encode('utf-8')
         nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)

--- a/aiohttp_session/redis_storage.py
+++ b/aiohttp_session/redis_storage.py
@@ -16,17 +16,16 @@ class RedisStorage(AbstractStorage):
     def __init__(self, redis_pool, *, cookie_name="AIOHTTP_SESSION",
                  domain=None, max_age=None, path='/',
                  secure=None, httponly=True,
-                 encoder=json.dumps, decoder=json.loads,
-                 key_factory=lambda: uuid.uuid4().hex):
+                 key_factory=lambda: uuid.uuid4().hex,
+                 encoder=json.dumps, decoder=json.loads):
         super().__init__(cookie_name=cookie_name, domain=domain,
                          max_age=max_age, path=path, secure=secure,
-                         httponly=httponly)
+                         httponly=httponly,
+                         encoder=encoder, decoder=decoder)
         if aioredis is None:
             raise RuntimeError("Please install aioredis")
         if StrictVersion(aioredis.__version__).version < (1, 0):
             raise RuntimeError("aioredis<1.0 is not supported")
-        self._encoder = encoder
-        self._decoder = decoder
         self._key_factory = key_factory
         if isinstance(redis_pool, aioredis.pool.ConnectionsPool):
             warnings.warn(

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -180,8 +180,8 @@ implement both :meth:`~AbstractStorage.load_session` and
    A callable with the following signature: `def encode(param: Any) -> str: ...`.
    Default is :func:`json.dumps`.
 
-   *decoder* -- session deserializer. A callable with the following signature:
-   `def decode(param: str) -> Any: ...`.
+   *decoder* -- session deserializer.
+   A callable with the following signature: `def decode(param: str) -> Any: ...`.
    Default is :func:`json.loads`.
 
    .. attribute:: max_age
@@ -200,15 +200,15 @@ implement both :meth:`~AbstractStorage.load_session` and
 
    .. attribute:: encoder
 
-      .. versionadded:: 2.3.0 
-
       The JSON serializer that will be used to dump session cookie data.
+
+      .. versionadded:: 2.3
 
    .. attribute:: decoder
 
-      .. versionadded:: 2.3.0 
-      
       The JSON deserializer that will be used to load session cookie data.
+
+      .. versionadded:: 2.3
 
    .. method:: load_session(request)
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -176,9 +176,13 @@ implement both :meth:`~AbstractStorage.load_session` and
    *httponly* -- cookie's http-only flag, :class:`bool` or ``None`` (the
    same as ``False``).
 
-   *encoder* -- json serializer, :class:`func`
+   *encoder* -- session serializer.
+   A callable with the following signature: `def encode(param: Any) -> str: ...`.
+   Default is :func:`json.dumps`.
 
-   *decoder* -- json deserializer, :class:`func`
+   *decoder* -- session deserializer. A callable with the following signature:
+   `def decode(param: str) -> Any: ...`.
+   Default is :func:`json.loads`.
 
    .. attribute:: max_age
 
@@ -196,11 +200,14 @@ implement both :meth:`~AbstractStorage.load_session` and
 
    .. attribute:: encoder
 
-      The JSON serializer that will be used to dump session cookie data.
+      .. versionadded:: 2.3.0 
 
+      The JSON serializer that will be used to dump session cookie data.
 
    .. attribute:: decoder
 
+      .. versionadded:: 2.3.0 
+      
       The JSON deserializer that will be used to load session cookie data.
 
    .. method:: load_session(request)
@@ -230,7 +237,6 @@ implement both :meth:`~AbstractStorage.load_session` and
 
       *max_age* is cookie lifetime given from session. Storage defailt
       is used if the value is ``None``.
-
 
 Simple Storage
 --------------

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -154,7 +154,8 @@ implement both :meth:`~AbstractStorage.load_session` and
 
 .. class:: AbstractStorage(cookie_name="AIOHTTP_SESSION", *, \
                            domain=None, max_age=None, path='/', \
-                           secure=None, httponly=True)
+                           secure=None, httponly=True, \
+                           encoder=json.parse, decoder=json.loads)
 
    Base class for session storage implementations.
 
@@ -175,6 +176,10 @@ implement both :meth:`~AbstractStorage.load_session` and
    *httponly* -- cookie's http-only flag, :class:`bool` or ``None`` (the
    same as ``False``).
 
+   *encoder* -- json serializer, :class:`func`
+
+   *decoder* -- json deserializer, :class:`func`
+
    .. attribute:: max_age
 
       Maximum age for session data, :class:`int` seconds or ``None``
@@ -188,6 +193,15 @@ implement both :meth:`~AbstractStorage.load_session` and
 
       :class:`dict` of cookie params: *domain*, *max_age*, *path*,
       *secure* and *httponly*.
+
+   .. attribute:: encoder
+
+      The JSON serializer that will be used to parse session cookie data.
+      
+
+   .. attribute:: decoder
+
+      The JSON deserializer that will be used to load session cookie data.
 
    .. method:: load_session(request)
 
@@ -235,7 +249,8 @@ To use the storage you should push it into
 .. class:: SimpleCookieStorage(*, \
                                cookie_name="AIOHTTP_SESSION", \
                                domain=None, max_age=None, path='/', \
-                               secure=None, httponly=True)
+                               secure=None, httponly=True, \
+                               encoder=json.parse, decoder=json.loads)
 
    Create unencrypted cookie storage.
 
@@ -265,7 +280,8 @@ To use the storage you should push it into
 .. class:: EncryptedCookieStorage(secret_key, *, \
                                   cookie_name="AIOHTTP_SESSION", \
                                   domain=None, max_age=None, path='/', \
-                                  secure=None, httponly=True)
+                                  secure=None, httponly=True, \
+                                  encoder=json.parse, decoder=json.loads)
 
    Create encryted cookies storage.
 
@@ -303,7 +319,8 @@ To use the storage you should push it into
 .. class:: NaClCookieStorage(secret_key, *, \
                                   cookie_name="AIOHTTP_SESSION", \
                                   domain=None, max_age=None, path='/', \
-                                  secure=None, httponly=True)
+                                  secure=None, httponly=True, \
+                                  encoder=json.parse, decoder=json.loads)
 
    Create encryted cookies storage.
 
@@ -339,9 +356,8 @@ To use the storage you need setup it first::
                         cookie_name="AIOHTTP_SESSION", \
                         domain=None, max_age=None, path='/', \
                         secure=None, httponly=True, \
-                        encoder=json.dumps, \
-                        decoder=json.loads, \
-                        key_factory=lambda: uuid.uuid4().hex)
+                        key_factory=lambda: uuid.uuid4().hex, \
+                        encoder=json.parse, decoder=json.loads)
 
    Create Redis storage for user session data.
 
@@ -377,9 +393,8 @@ To use the storage you need setup it first::
                             cookie_name="AIOHTTP_SESSION", \
                             domain=None, max_age=None, path='/', \
                             secure=None, httponly=True, \
-                            encoder=json.dumps, \
-                            decoder=json.loads, \
-                            key_factory=lambda: uuid.uuid4().hex)
+                            key_factory=lambda: uuid.uuid4().hex, \
+                            encoder=json.parse, decoder=json.loads)
 
    Create Memcached storage for user session data.
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -155,7 +155,7 @@ implement both :meth:`~AbstractStorage.load_session` and
 .. class:: AbstractStorage(cookie_name="AIOHTTP_SESSION", *, \
                            domain=None, max_age=None, path='/', \
                            secure=None, httponly=True, \
-                           encoder=json.parse, decoder=json.loads)
+                           encoder=json.dumps, decoder=json.loads)
 
    Base class for session storage implementations.
 
@@ -196,8 +196,8 @@ implement both :meth:`~AbstractStorage.load_session` and
 
    .. attribute:: encoder
 
-      The JSON serializer that will be used to parse session cookie data.
-      
+      The JSON serializer that will be used to dump session cookie data.
+
 
    .. attribute:: decoder
 
@@ -250,7 +250,7 @@ To use the storage you should push it into
                                cookie_name="AIOHTTP_SESSION", \
                                domain=None, max_age=None, path='/', \
                                secure=None, httponly=True, \
-                               encoder=json.parse, decoder=json.loads)
+                               encoder=json.dumps, decoder=json.loads)
 
    Create unencrypted cookie storage.
 
@@ -281,7 +281,7 @@ To use the storage you should push it into
                                   cookie_name="AIOHTTP_SESSION", \
                                   domain=None, max_age=None, path='/', \
                                   secure=None, httponly=True, \
-                                  encoder=json.parse, decoder=json.loads)
+                                  encoder=json.dumps, decoder=json.loads)
 
    Create encryted cookies storage.
 
@@ -320,7 +320,7 @@ To use the storage you should push it into
                                   cookie_name="AIOHTTP_SESSION", \
                                   domain=None, max_age=None, path='/', \
                                   secure=None, httponly=True, \
-                                  encoder=json.parse, decoder=json.loads)
+                                  encoder=json.dumps, decoder=json.loads)
 
    Create encryted cookies storage.
 
@@ -357,7 +357,7 @@ To use the storage you need setup it first::
                         domain=None, max_age=None, path='/', \
                         secure=None, httponly=True, \
                         key_factory=lambda: uuid.uuid4().hex, \
-                        encoder=json.parse, decoder=json.loads)
+                        encoder=json.dumps, decoder=json.loads)
 
    Create Redis storage for user session data.
 
@@ -394,7 +394,7 @@ To use the storage you need setup it first::
                             domain=None, max_age=None, path='/', \
                             secure=None, httponly=True, \
                             key_factory=lambda: uuid.uuid4().hex, \
-                            encoder=json.parse, decoder=json.loads)
+                            encoder=json.dumps, decoder=json.loads)
 
    Create Memcached storage for user session data.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,17 @@ import pytest
 import time
 import uuid
 from docker import Client as DockerClient
+import socket
+
+
+@pytest.fixture(scope='session')
+def unused_port():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("", 0))
+    s.listen(1)
+    port = s.getsockname()[1]
+    s.close()
+    return port
 
 
 @pytest.fixture(scope='session')
@@ -43,20 +54,39 @@ def pytest_addoption(parser):
 def redis_server(docker, session_id, loop, request):
     if not request.config.option.no_pull:
         docker.pull('redis:{}'.format('latest'))
+
+    """
     container = docker.create_container(
         image='redis:{}'.format('latest'),
         name='redis-test-server-{}-{}'.format('latest', session_id),
         ports=[6379],
         detach=True,
     )
+    """
+
+    container_args = dict(
+        image='redis:{}'.format('latest'),
+        name='redis-test-server-{}-{}'.format('latest', session_id),
+        ports=[6379],
+        detach=True,
+    )
+
+    # bound IPs do not work on OSX
+    host = "127.0.0.1"
+    host_port = unused_port()
+    container_args['host_config'] = docker.create_host_config(
+        port_bindings={6379: (host, host_port)})
+
+    container = docker.create_container(**container_args)
+
     docker.start(container=container['Id'])
-    inspection = docker.inspect_container(container['Id'])
-    host = inspection['NetworkSettings']['IPAddress']
+    # inspection = docker.inspect_container(container['Id'])
+    # host = inspection['NetworkSettings']['IPAddress']
     delay = 0.001
     for i in range(100):
         try:
             conn = loop.run_until_complete(
-                aioredis.create_connection((host, 6379), loop=loop)
+                aioredis.create_connection((host, host_port), loop=loop)
             )
             loop.run_until_complete(conn.execute('SET', 'foo', 'bar'))
             break
@@ -65,7 +95,7 @@ def redis_server(docker, session_id, loop, request):
             delay *= 2
     else:
         pytest.fail("Cannot start redis server")
-    container['redis_params'] = dict(address=(host, 6379))
+    container['redis_params'] = dict(address=(host, host_port))
     yield container
 
     docker.kill(container=container['Id'])
@@ -100,19 +130,36 @@ def redis(loop, redis_params):
 def memcached_server(docker, session_id, loop, request):
     if not request.config.option.no_pull:
         docker.pull('memcached:{}'.format('latest'))
+
+    """
     container = docker.create_container(
         image='memcached:{}'.format('latest'),
         name='memcached-test-server-{}-{}'.format('latest', session_id),
         ports=[11211],
         detach=True,
     )
+    """
+
+    container_args = dict(
+        image='memcached:{}'.format('latest'),
+        name='memcached-test-server-{}-{}'.format('latest', session_id),
+        ports=[11211],
+        detach=True,
+    )
+
+    # bound IPs do not work on OSX
+    host = "127.0.0.1"
+    host_port = unused_port()
+    container_args['host_config'] = docker.create_host_config(
+        port_bindings={11211: (host, host_port)})
+    container = docker.create_container(**container_args)
     docker.start(container=container['Id'])
-    inspection = docker.inspect_container(container['Id'])
-    host = inspection['NetworkSettings']['IPAddress']
+    # inspection = docker.inspect_container(container['Id'])
+    # host = inspection['NetworkSettings']['IPAddress']
     delay = 0.001
     for i in range(100):
         try:
-            conn = aiomcache.Client(host, 11211, loop=loop)
+            conn = aiomcache.Client(host, host_port, loop=loop)
             loop.run_until_complete(conn.set(b'foo', b'bar'))
             break
         except ConnectionRefusedError as e:
@@ -120,7 +167,7 @@ def memcached_server(docker, session_id, loop, request):
             delay *= 2
     else:
         pytest.fail("Cannot start memcached server")
-    container['memcached_params'] = dict(host=host, port=11211)
+    container['memcached_params'] = dict(host=host, port=host_port)
     yield container
 
     docker.kill(container=container['Id'])


### PR DESCRIPTION
I left the args explicit, means that json still needs to be imported in all files. The first solution using kwargs seemed kind of odd considering we're passing through everything else explicitly.

I didn't really look into it much but I couldn't get all tests to run because docker seems to be having hiccups at some point. Not sure if MacOS might be the culprit here.

About the docs, :class:`func` doesn't seem right but I'm new to Sphinx docs and couldn't get :func: parameters to work.
