### PR TITLE
fix typos in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,9 +80,9 @@ Available session storages are:
 * ``aiohttp_session.redis_storage.RedisStorage(redis_pool)`` -- stores
   JSON encoded data in *redis*, keeping only the redis key (a random UUID) in
   the cookie. ``redis_pool`` is a ``aioredis`` pool object, created by
-  ``await aioredis.create_resid_pool(...)`` call.
+  ``await aioredis.create_redis_pool(...)`` call.
 
-  Requires ``aioredis`` library (olny versions ``1.0+`` are supported::
+  Requires ``aioredis`` library (only versions ``1.0+`` are supported)::
 
       $ pip install aiohttp_session[aioredis]
 


### PR DESCRIPTION
Low priority.

A typo in the `aioredis` access, and two in the requirement specification for `aioredis`.