### PR TITLE
Patch Session Fixation in Redis Storage

### DIFF
--- a/aiohttp_session/__init__.py
+++ b/aiohttp_session/__init__.py
@@ -18,13 +18,14 @@ class Session(MutableMapping):
     def __init__(self, identity, *, data, new, max_age=None):
         self._changed = False
         self._mapping = {}
-        self._identity = identity
+        self._identity = identity if data != {} else None
         self._new = new
+        self._new = new if data != {} else True
         self._max_age = max_age
         created = data.get('created', None) if data else None
         session_data = data.get('session', None) if data else None
 
-        if new or created is None:
+        if self._new or created is None:
             self._created = int(time.time())
         else:
             self._created = created

--- a/aiohttp_session/redis_storage.py
+++ b/aiohttp_session/redis_storage.py
@@ -47,7 +47,7 @@ class RedisStorage(AbstractStorage):
             with await self._redis as conn:
                 key = str(cookie)
                 data = await conn.get(self.cookie_name + '_' + key)
-                if data is None or data == b'{}':
+                if data is None:
                     return Session(None, data=None,
                                    new=True, max_age=self.max_age)
                 data = data.decode('utf-8')

--- a/aiohttp_session/redis_storage.py
+++ b/aiohttp_session/redis_storage.py
@@ -47,7 +47,7 @@ class RedisStorage(AbstractStorage):
             with await self._redis as conn:
                 key = str(cookie)
                 data = await conn.get(self.cookie_name + '_' + key)
-                if data is None:
+                if data is None or data == b'{}':
                     return Session(None, data=None,
                                    new=True, max_age=self.max_age)
                 data = data.decode('utf-8')

--- a/tests/test_encrypted_cookie_storage.py
+++ b/tests/test_encrypted_cookie_storage.py
@@ -136,3 +136,26 @@ async def test_clear_cookie_on_session_invalidation(aiohttp_client,
     assert '' == morsel.value
     assert not morsel['httponly']
     assert morsel['path'] == '/'
+
+async def test_encrypted_cookie_session_fixation(aiohttp_client, fernet, key):
+    async def login(request):
+        session = await get_session(request)
+        session['k'] = 'v'
+        return web.Response()
+
+    async def logout(request):
+        session = await get_session(request)
+        session.invalidate()
+        return web.Response()
+
+    app = create_app(login, key)
+    app.router.add_route('DELETE', '/', logout)
+    client = await aiohttp_client(app)
+    resp = await client.get('/')
+    assert 'AIOHTTP_SESSION' in resp.cookies
+    evil_cookie = resp.cookies['AIOHTTP_SESSION'].value
+    resp = await client.delete('/')
+    assert resp.cookies['AIOHTTP_SESSION'].value == ""
+    client.session.cookie_jar.update_cookies({'AIOHTTP_SESSION': evil_cookie})
+    resp = await client.get('/')
+    assert resp.cookies['AIOHTTP_SESSION'].value != evil_cookie

--- a/tests/test_encrypted_cookie_storage.py
+++ b/tests/test_encrypted_cookie_storage.py
@@ -137,6 +137,7 @@ async def test_clear_cookie_on_session_invalidation(aiohttp_client,
     assert not morsel['httponly']
     assert morsel['path'] == '/'
 
+
 async def test_encrypted_cookie_session_fixation(aiohttp_client, fernet, key):
     async def login(request):
         session = await get_session(request)

--- a/tests/test_memcached_storage.py
+++ b/tests/test_memcached_storage.py
@@ -204,6 +204,7 @@ async def test_create_storate_with_custom_key_factory(aiohttp_client,
     assert 'key' in value['session']
     assert value['session']['key'] == 'value'
 
+
 async def test_memcached_session_fixation(aiohttp_client, memcached):
     async def login(request):
         session = await get_session(request)

--- a/tests/test_nacl_storage.py
+++ b/tests/test_nacl_storage.py
@@ -130,6 +130,7 @@ async def test_del_cookie_on_session_invalidation(aiohttp_client,
     assert not morsel['httponly']
     assert morsel['path'] == '/'
 
+
 async def test_nacl_session_fixation(aiohttp_client, secretbox, key):
     async def login(request):
         session = await get_session(request)

--- a/tests/test_nacl_storage.py
+++ b/tests/test_nacl_storage.py
@@ -129,3 +129,26 @@ async def test_del_cookie_on_session_invalidation(aiohttp_client,
     assert '' == morsel.value
     assert not morsel['httponly']
     assert morsel['path'] == '/'
+
+async def test_nacl_session_fixation(aiohttp_client, secretbox, key):
+    async def login(request):
+        session = await get_session(request)
+        session['k'] = 'v'
+        return web.Response()
+
+    async def logout(request):
+        session = await get_session(request)
+        session.invalidate()
+        return web.Response()
+
+    app = create_app(login, key)
+    app.router.add_route('DELETE', '/', logout)
+    client = await aiohttp_client(app)
+    resp = await client.get('/')
+    assert 'AIOHTTP_SESSION' in resp.cookies
+    evil_cookie = resp.cookies['AIOHTTP_SESSION'].value
+    resp = await client.delete('/')
+    assert resp.cookies['AIOHTTP_SESSION'].value == ""
+    client.session.cookie_jar.update_cookies({'AIOHTTP_SESSION': evil_cookie})
+    resp = await client.get('/')
+    assert resp.cookies['AIOHTTP_SESSION'].value != evil_cookie

--- a/tests/test_redis_storage.py
+++ b/tests/test_redis_storage.py
@@ -245,6 +245,30 @@ async def test_create_storate_with_custom_key_factory(aiohttp_client, redis):
     assert value['session']['key'] == 'value'
 
 
+async def test_redis_session_fixation(aiohttp_client, redis):
+    async def login(request):
+        session = await get_session(request)
+        session['k'] = 'v'
+        return web.Response()
+
+    async def logout(request):
+        session = await get_session(request)
+        session.invalidate()
+        return web.Response()
+
+    app = create_app(login, redis)
+    app.router.add_route('DELETE', '/', logout)
+    client = await aiohttp_client(app)
+    resp = await client.get('/')
+    assert 'AIOHTTP_SESSION' in resp.cookies
+    evil_cookie = resp.cookies['AIOHTTP_SESSION'].value
+    resp = await client.delete('/')
+    assert resp.cookies['AIOHTTP_SESSION'].value == ""
+    client.session.cookie_jar.update_cookies({'AIOHTTP_SESSION': evil_cookie})
+    resp = await client.get('/')
+    assert resp.cookies['AIOHTTP_SESSION'].value != evil_cookie
+
+
 async def test_redis_from_create_pool(redis_params):
 
     async def handler(request):


### PR DESCRIPTION
Fixes #272 .

This is a relatively naive approach on patching the issue and there probably should be a more general/broad look into it design wise at some point. 

The reason I chose this solution is that it effectively patches the vulnerability without altering the library's behavior (i.e. what is saved in the database).