### PR TITLE
Remove redundant import from sphinx conf

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,6 @@ import sys
 import os
 import codecs
 import re
-import alabaster
 
 _docs_path = os.path.dirname(__file__)
 _version_path = os.path.abspath(os.path.join(_docs_path,
@@ -156,7 +155,7 @@ html_theme_options = {
 }
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [alabaster.get_path()]
+html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,9 @@ The session object has dict-like interface (operations like
 Before processing session in web-handler you have to register *session
 middleware* in :class:`aiohttp.web.Application`.
 
-A trivial usage example::
+A trivial usage example:
+
+.. code-block:: python
 
     import time
     from aiohttp import web
@@ -59,11 +61,11 @@ Available session storages are:
 
   For key generation use :meth:`cryptography.fernet.Fernet.generate_key` method.
 
-  Requires :term:`cryptography` library::
+  Requires :term:`cryptography` library:
 
-  .. code::
+  .. code-block:: bash
 
-     $ pip3 install aiohttp_session[secure]
+      $ pip3 install aiohttp_session[secure]
 
 * :class:`~aiohttp_session.redis_storage.RedisStorage` -- stores
   JSON-ed data into *redis*, keeping into cookie only redis key


### PR DESCRIPTION
This PR is intended to fix #284 . RTD builds are failing for quite some time with
```
Exception occurred:
  File "conf.py", line 158, in <module>
    html_theme_path = [alabaster.get_path()]
NameError: name 'alabaster' is not defined
```

According to [alabaster docs](https://alabaster.readthedocs.io/en/latest/installation.html) this config option is redundant since Sphinx 1.3.