### PR TITLE
Fix the travis build badge and codecov badge in the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,7 +140,7 @@ html_theme_options = {
     'logo': 'aiohttp-icon-128x128.png',
     'description': 'user session support for aiohttp.web',
     'github_user': 'aio-libs',
-    'github_repo': 'aiohttp_session',
+    'github_repo': 'aiohttp-session',
     'github_button': True,
     'github_type': 'star',
     'github_banner': True,


### PR DESCRIPTION
Currently in http://aiohttp-session.readthedocs.io/en/latest/, the badges are saying "unknown".

With this fix, it will show the correct badges:

<img width="622" alt="screen shot 2018-06-24 at 10 26 44 pm" src="https://user-images.githubusercontent.com/5844587/41831830-0ebba5d0-77fe-11e8-8b22-97930760ef5c.png">
