### PR TITLE
import from collections.abc instead of from collections.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,13 @@
 Changes
 =======
 
+2.8.0 (2019-05-29)
+------------------
+
+* Make this compatible with Python 3.7+. Import from collections.abc, instead
+  of from collections.
+
+
 2.7.0 (2018-10-13)
 ------------------
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ Changes
 ------------------
 
 * Make this compatible with Python 3.7+. Import from collections.abc, instead
-  of from collections.
+  of from collections. (#373)
 
 
 2.7.0 (2018-10-13)

--- a/aiohttp_session/__init__.py
+++ b/aiohttp_session/__init__.py
@@ -2,13 +2,10 @@
 
 import abc
 
-try:
-    from collections.abc import MutableMapping
-except ImportError:  # pragma: no cover
-    from collections import MutableMapping
-
 import json
 import time
+
+from collections.abc import MutableMapping
 
 from aiohttp import web
 

--- a/aiohttp_session/__init__.py
+++ b/aiohttp_session/__init__.py
@@ -4,7 +4,7 @@ import abc
 
 try:
     from collections.abc import MutableMapping
-except ImportError:
+except ImportError:  # pragma: no cover
     from collections import MutableMapping
 
 import json

--- a/aiohttp_session/__init__.py
+++ b/aiohttp_session/__init__.py
@@ -1,7 +1,12 @@
 """User sessions for aiohttp.web."""
 
 import abc
-from collections import MutableMapping
+
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
+
 import json
 import time
 
@@ -157,7 +162,7 @@ def session_middleware(storage):
             raise RuntimeError(
                 "Expect response, not {!r}".format(type(response)))
         if not isinstance(response, web.Response):
-            # likely got websoket or streaming
+            # likely got websocket or streaming
             return response
         if response.prepared:
             raise RuntimeError(


### PR DESCRIPTION
To address pending deprecation warning.

<!-- Thank you for your contribution! -->

## What do these changes do?

Instead of importing from collections, import from collections.abc

## Are there changes in behavior for the user?

Users in 3.7+ would see deprecation warning:
```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```

With this change, the deprecation warning disappears in Python 3.7.1+

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
