### PR TITLE
Fix travis CI badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 aiohttp_session
 ===============
-.. image:: https://travis-ci.org/aio-libs/aiohttp-session.svg?branch=master
-    :target: https://travis-ci.org/aio-libs/aiohttp-session
+.. image:: https://travis-ci.com/aio-libs/aiohttp-session.svg?branch=master
+    :target: https://travis-ci.com/aio-libs/aiohttp-session
 .. image:: https://codecov.io/github/aio-libs/aiohttp-session/coverage.svg?branch=master
     :target: https://codecov.io/github/aio-libs/aiohttp-session
 .. image:: https://readthedocs.org/projects/aiohttp-session/badge/?version=latest


### PR DESCRIPTION
It has moved from travis-ci.org to travis-ci.com

<!-- Thank you for your contribution! -->

## What do these changes do?

Update the Travis CI badge in readme. Currently it is not rendered.

## Are there changes in behavior for the user?

With this fix, readers can see the proper travis CI badge in readme.


## Related issue number

None

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
