### PR TITLE
[Doc] Return string not bytes for uniformity's sake

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ A trivial usage example:
     async def handler(request):
         session = await get_session(request)
         session['last_visit'] = time.time()
-        return web.Response(body=b'OK')
+        return web.Response(body='OK')
 
     def init():
         app = web.Application()


### PR DESCRIPTION
## What do these changes do?

In the main documentation page, change the return body of the 'Usage' example to pass a `string` to the `web.Response` object's constructor instead of `bytes` object.

This is not a real issue but since it has already confused one user (see related issue number section bellow) and it is the only place in `aiohttp-session` examples where `bytes` is provided to the `web.Response` constructor I suggest this change purely for the sake of uniformity (and to avoid any confusion).

## Are there changes in behavior for the user?

None.

## Related issue number

Closes #368 .

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`

That's only a docs change and the 'CHANGES' folder doesn't exist so the above are check as 'doesn't apply' ;)