### PR TITLE
Custom Storage key/Redis delimiters

### DIFF
--- a/aiohttp_session/__init__.py
+++ b/aiohttp_session/__init__.py
@@ -183,10 +183,12 @@ def setup(app, storage):
 class AbstractStorage(metaclass=abc.ABCMeta):
 
     def __init__(self, *, cookie_name="AIOHTTP_SESSION",
-                 domain=None, max_age=None, path='/',
+                 key_delimiter="_", domain=None,
+                 max_age=None, path='/',
                  secure=None, httponly=True,
                  encoder=json.dumps, decoder=json.loads):
         self._cookie_name = cookie_name
+        self._key_delimiter = key_delimiter
         self._cookie_params = dict(domain=domain,
                                    max_age=max_age,
                                    path=path,

--- a/aiohttp_session/memcached_storage.py
+++ b/aiohttp_session/memcached_storage.py
@@ -14,8 +14,9 @@ class MemcachedStorage(AbstractStorage):
                  key_factory=lambda: uuid.uuid4().hex, encoder=json.dumps,
                  decoder=json.loads):
         super().__init__(cookie_name=cookie_name, key_delimiter=key_delimiter,
-                         domain=domain, max_age=max_age, path=path, secure=secure,
-                         httponly=httponly, encoder=encoder, decoder=decoder)
+                         domain=domain, max_age=max_age, path=path,
+                         secure=secure, httponly=httponly, encoder=encoder,
+                         decoder=decoder)
         self._key_factory = key_factory
         self.conn = memcached_conn
 
@@ -25,7 +26,8 @@ class MemcachedStorage(AbstractStorage):
             return Session(None, data=None, new=True, max_age=self.max_age)
         else:
             key = str(cookie)
-            stored_key = (self.cookie_name + self._key_delimiter + key).encode('utf-8')
+            stored_key = (self.cookie_name + self._key_delimiter
+                          + key).encode('utf-8')
             data = await self.conn.get(stored_key)
             if data is None:
                 return Session(None, data=None,
@@ -65,7 +67,8 @@ class MemcachedStorage(AbstractStorage):
             expire = int(time()) + max_age
         else:
             expire = max_age
-        stored_key = (self.cookie_name + self._key_delimiter + key).encode('utf-8')
+        stored_key = (self.cookie_name + self._key_delimiter
+                      + key).encode('utf-8')
         await self.conn.set(
                                 stored_key, data.encode('utf-8'),
                                 exptime=expire)

--- a/aiohttp_session/redis_storage.py
+++ b/aiohttp_session/redis_storage.py
@@ -19,8 +19,9 @@ class RedisStorage(AbstractStorage):
                  key_factory=lambda: uuid.uuid4().hex,
                  encoder=json.dumps, decoder=json.loads):
         super().__init__(cookie_name=cookie_name, key_delimiter=key_delimiter,
-                         domain=domain, max_age=max_age, path=path, secure=secure,
-                         httponly=httponly, encoder=encoder, decoder=decoder)
+                         domain=domain, max_age=max_age, path=path,
+                         secure=secure, httponly=httponly, encoder=encoder,
+                         decoder=decoder)
         if aioredis is None:
             raise RuntimeError("Please install aioredis")
         if StrictVersion(aioredis.__version__).version < (1, 0):
@@ -45,7 +46,8 @@ class RedisStorage(AbstractStorage):
         else:
             with await self._redis as conn:
                 key = str(cookie)
-                data = await conn.get(self.cookie_name + self._key_delimiter + key)
+                data = await conn.get(self.cookie_name + self._key_delimiter
+                                      + key)
                 if data is None:
                     return Session(None, data=None,
                                    new=True, max_age=self.max_age)
@@ -75,4 +77,5 @@ class RedisStorage(AbstractStorage):
         with await self._redis as conn:
             max_age = session.max_age
             expire = max_age if max_age is not None else 0
-            await conn.set(self.cookie_name + self._key_delimiter + key, data, expire=expire)
+            await conn.set(self.cookie_name + self._key_delimiter
+                           + key, data, expire=expire)

--- a/aiohttp_session/redis_storage.py
+++ b/aiohttp_session/redis_storage.py
@@ -14,7 +14,7 @@ class RedisStorage(AbstractStorage):
     """Redis storage"""
 
     def __init__(self, redis_pool, *, cookie_name="AIOHTTP_SESSION",
-                 key_delimiter=":", domain=None, max_age=None,
+                 key_delimiter="_", domain=None, max_age=None,
                  path='/', secure=None, httponly=True,
                  key_factory=lambda: uuid.uuid4().hex,
                  encoder=json.dumps, decoder=json.loads):

--- a/aiohttp_session/redis_storage.py
+++ b/aiohttp_session/redis_storage.py
@@ -13,7 +13,7 @@ from . import AbstractStorage, Session
 class RedisStorage(AbstractStorage):
     """Redis storage"""
 
-    def __init__(self, redis_pool, *, cookie_name="SESS",
+    def __init__(self, redis_pool, *, cookie_name="AIOHTTP_SESSION",
                  key_delimiter=":", domain=None, max_age=None,
                  path='/', secure=None, httponly=True,
                  key_factory=lambda: uuid.uuid4().hex,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,7 +75,8 @@ Available session storages are:
 
   Inside redis the key will be saved as COOKIENAME_VALUEOFTHECOOKIE.
   For example if inside the browser the cookie is saved with name
-  ``'AIOHTTP_SESSION'`` (default option) and value
+  ``'AIOHTTP_SESSION'`` (default option) with the delimiter
+  ``:`` (default delimiter) and value
   ``e33b57c7ec6e425eb626610f811ab6ae`` (a random UUID) they key inside
   redis will be ``AIOHTTP_SESSION_e33b57c7ec6e425eb626610f811ab6ae``.
 


### PR DESCRIPTION
Branch adds user-specified Redis and other storage key delimiters. People are very opinionated about the structure of their Redis keys and `_` is rarely used. Delimiter can now be specified at instantiation and defaults to `:` for Redis.

End user will not experience any difference in service.

`.feature`

