### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,15 @@ services:
 - docker
 
 python:
-- 3.5
 - 3.6
+- 3.7
 - nightly
 
 jobs:
   allow_failures:
   - python: nightly
-  - python: 3.7
 
   include:
-  - python: 3.7
-    dist: xenial
-    sudo: true
-
   - stage: Deploy
     name: Publishing dists to PyPI
     if: tag IS present


### PR DESCRIPTION
Drop Python 3.5

In general, the library should migrate to GitHub actions but small Travis config change doesn't harm