### PR TITLE
Predicate method to test for active session

### DIFF
--- a/aiohttp_session/__init__.py
+++ b/aiohttp_session/__init__.py
@@ -104,6 +104,12 @@ class Session(MutableMapping):
 SESSION_KEY = 'aiohttp_session'
 STORAGE_KEY = 'aiohttp_session_storage'
 
+async def is_active_session(request):
+    cookie = storage.load_cookie(request)
+    if cookie is not None:
+        return True
+    else:
+        return False
 
 async def get_session(request):
     session = request.get(SESSION_KEY)


### PR DESCRIPTION
Using `get_session()` always activates a new session, from `session = await storage.load_session(request)`. That's ok for some contexts, but not for some situations (like authentication verification contexts).

<!-- Thank you for your contribution!  YOU'RE WELCOME! -->

## What do these changes do?

Added a simply predicate which checks the available storage for a saved **AIOHTTP_SESSION** cookie, returning True if one Found, False otherwise.

An alternative(?) to adding this new function would be to add an optional boolean flag directly to the get_session() method, which allows creation of the new session cookie but otherwise triggers the raising of a RunTimeError if there is no session cookie is already available in the session storage. Not sure what to call such a flag - maybe `create`? -nor what its default value ought to be (perhaps **True** to maintain non-breaking backwards compatibility to library users).

Maybe both changes could be pondered although the second option seems more challenging to implement due to the embedded call to `storage.load_session(request)`.

Either way, one can test first if a session is active, then get it afterwards or otherwise make a suitable application decision to create one (or work outside such a session, e.g. for public non-authenticated access).

## Are there changes in behavior for the user?

No, unless they use the new function. But if they have the problem with get_session() described above, then this function should be useful.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

n/a - this PR documents the problem

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
