### PR TITLE
Use release environment for deploy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
 
   deploy:
     name: Deploy
+    environment: release
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     needs: [test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
@webknjaz Do you want to setup the release env? I've tested this on aiohttp-devtools and it works.

Although, worth noting that I ran the deploy in the wrong environment first time and the CI says the deploy was a success despite it not uploading to pyPI.