### PR TITLE
Add support for Python 3.14 and drop EOL 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v6
       with:
-        python-version: 3.13
+        python-version: 3.14
         cache: 'pip'
         cache-dependency-path: '**/requirements*.txt'
     - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Checkout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
       - id: detect-private-key
         exclude: ^examples/
   - repo: https://github.com/asottile/pyupgrade
-    rev: "v3.1.0"
+    rev: "v3.21.2"
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
     rev: "v3.21.2"
     hooks:
       - id: pyupgrade
-        args: ["--py38-plus"]
+        args: ["--py310-plus"]
   - repo: https://github.com/PyCQA/flake8
     rev: "7.1.1"
     hooks:

--- a/aiohttp_session/__init__.py
+++ b/aiohttp_session/__init__.py
@@ -5,35 +5,26 @@ __version__ = "2.12.1"
 import abc
 import json
 import time
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterator,
-    MutableMapping,
-    Optional,
-    TypedDict,
-    Union,
-    cast,
-)
+from collections.abc import Callable, Iterator, MutableMapping
+from typing import Any, TypedDict, cast
 
 from aiohttp import web
 from aiohttp.typedefs import Handler, Middleware
 
 
 class _CookieParams(TypedDict, total=False):
-    domain: Optional[str]
-    max_age: Optional[int]
+    domain: str | None
+    max_age: int | None
     path: str
-    secure: Optional[bool]
+    secure: bool | None
     httponly: bool
-    samesite: Optional[str]
+    samesite: str | None
     expires: str
 
 
 class SessionData(TypedDict, total=False):
     created: int
-    session: Dict[str, Any]
+    session: dict[str, Any]
 
 
 class Session(MutableMapping[str, Any]):
@@ -42,14 +33,14 @@ class Session(MutableMapping[str, Any]):
 
     def __init__(
         self,
-        identity: Optional[Any],
+        identity: Any | None,
         *,
-        data: Optional[SessionData],
+        data: SessionData | None,
         new: bool,
-        max_age: Optional[int] = None,
+        max_age: int | None = None,
     ) -> None:
         self._changed: bool = False
-        self._mapping: Dict[str, Any] = {}
+        self._mapping: dict[str, Any] = {}
         self._identity = identity if data != {} else None
         self._new = new if data != {} else True
         self._max_age = max_age
@@ -81,7 +72,7 @@ class Session(MutableMapping[str, Any]):
         return self._new
 
     @property
-    def identity(self) -> Optional[Any]:
+    def identity(self) -> Any | None:
         return self._identity
 
     @property
@@ -93,11 +84,11 @@ class Session(MutableMapping[str, Any]):
         return not bool(self._mapping)
 
     @property
-    def max_age(self) -> Optional[int]:
+    def max_age(self) -> int | None:
         return self._max_age
 
     @max_age.setter
-    def max_age(self, value: Optional[int]) -> None:
+    def max_age(self, value: int | None) -> None:
         self._max_age = value
 
     def changed(self) -> None:
@@ -107,7 +98,7 @@ class Session(MutableMapping[str, Any]):
         self._changed = True
         self._mapping = {}
 
-    def set_new_identity(self, identity: Optional[Any]) -> None:
+    def set_new_identity(self, identity: Any | None) -> None:
         if not self._new:
             raise RuntimeError("Can't change identity for a session which is not new")
 
@@ -186,7 +177,7 @@ def session_middleware(storage: "AbstractStorage") -> Middleware:
         raise_response = False
         # TODO aiohttp 4:
         # Remove Union from response, and drop the raise_response variable
-        response: Union[web.StreamResponse, web.HTTPException]
+        response: web.StreamResponse | web.HTTPException
         try:
             response = await handler(request)
         except web.HTTPException as exc:
@@ -221,12 +212,12 @@ class AbstractStorage(metaclass=abc.ABCMeta):
         self,
         *,
         cookie_name: str = "AIOHTTP_SESSION",
-        domain: Optional[str] = None,
-        max_age: Optional[int] = None,
+        domain: str | None = None,
+        max_age: int | None = None,
         path: str = "/",
-        secure: Optional[bool] = None,
+        secure: bool | None = None,
         httponly: bool = True,
-        samesite: Optional[str] = None,
+        samesite: str | None = None,
         encoder: Callable[[object], str] = json.dumps,
         decoder: Callable[[str], Any] = json.loads,
     ) -> None:
@@ -248,7 +239,7 @@ class AbstractStorage(metaclass=abc.ABCMeta):
         return self._cookie_name
 
     @property
-    def max_age(self) -> Optional[int]:
+    def max_age(self) -> int | None:
         return self._max_age
 
     @property
@@ -274,7 +265,7 @@ class AbstractStorage(metaclass=abc.ABCMeta):
     ) -> None:
         pass
 
-    def load_cookie(self, request: web.Request) -> Optional[str]:
+    def load_cookie(self, request: web.Request) -> str | None:
         return request.cookies.get(self._cookie_name)
 
     def save_cookie(
@@ -282,7 +273,7 @@ class AbstractStorage(metaclass=abc.ABCMeta):
         response: web.StreamResponse,
         cookie_data: str,
         *,
-        max_age: Optional[int] = None,
+        max_age: int | None = None,
     ) -> None:
         params = self._cookie_params.copy()
         if max_age is not None:
@@ -306,12 +297,12 @@ class SimpleCookieStorage(AbstractStorage):
         self,
         *,
         cookie_name: str = "AIOHTTP_SESSION",
-        domain: Optional[str] = None,
-        max_age: Optional[int] = None,
+        domain: str | None = None,
+        max_age: int | None = None,
         path: str = "/",
-        secure: Optional[bool] = None,
+        secure: bool | None = None,
         httponly: bool = True,
-        samesite: Optional[str] = None,
+        samesite: str | None = None,
         encoder: Callable[[object], str] = json.dumps,
         decoder: Callable[[str], Any] = json.loads,
     ) -> None:

--- a/aiohttp_session/cookie_storage.py
+++ b/aiohttp_session/cookie_storage.py
@@ -1,6 +1,7 @@
 import base64
 import json
-from typing import Any, Callable, Optional, Union
+from collections.abc import Callable
+from typing import Any
 
 from aiohttp import web
 from cryptography import fernet
@@ -15,15 +16,15 @@ class EncryptedCookieStorage(AbstractStorage):
 
     def __init__(
         self,
-        secret_key: Union[str, bytes, bytearray, fernet.Fernet],
+        secret_key: str | bytes | bytearray | fernet.Fernet,
         *,
         cookie_name: str = "AIOHTTP_SESSION",
-        domain: Optional[str] = None,
-        max_age: Optional[int] = None,
+        domain: str | None = None,
+        max_age: int | None = None,
         path: str = "/",
-        secure: Optional[bool] = None,
+        secure: bool | None = None,
         httponly: bool = True,
-        samesite: Optional[str] = None,
+        samesite: str | None = None,
         encoder: Callable[[object], str] = json.dumps,
         decoder: Callable[[str], Any] = json.loads
     ) -> None:

--- a/aiohttp_session/memcached_storage.py
+++ b/aiohttp_session/memcached_storage.py
@@ -1,7 +1,8 @@
 import json
 import uuid
+from collections.abc import Callable
 from time import time
-from typing import Any, Callable, Optional
+from typing import Any
 
 import aiomcache
 from aiohttp import web
@@ -17,12 +18,12 @@ class MemcachedStorage(AbstractStorage):
         memcached_conn: aiomcache.Client,
         *,
         cookie_name: str = "AIOHTTP_SESSION",
-        domain: Optional[str] = None,
-        max_age: Optional[int] = None,
+        domain: str | None = None,
+        max_age: int | None = None,
         path: str = "/",
-        secure: Optional[bool] = None,
+        secure: bool | None = None,
         httponly: bool = True,
-        samesite: Optional[str] = None,
+        samesite: str | None = None,
         key_factory: Callable[[], str] = lambda: uuid.uuid4().hex,
         encoder: Callable[[object], str] = json.dumps,
         decoder: Callable[[str], Any] = json.loads

--- a/aiohttp_session/nacl_storage.py
+++ b/aiohttp_session/nacl_storage.py
@@ -1,6 +1,7 @@
 import binascii
 import json
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 import nacl.exceptions
 import nacl.secret
@@ -20,12 +21,12 @@ class NaClCookieStorage(AbstractStorage):
         secret_key: bytes,
         *,
         cookie_name: str = "AIOHTTP_SESSION",
-        domain: Optional[str] = None,
-        max_age: Optional[int] = None,
+        domain: str | None = None,
+        max_age: int | None = None,
         path: str = "/",
-        secure: Optional[bool] = None,
+        secure: bool | None = None,
         httponly: bool = True,
-        samesite: Optional[str] = None,
+        samesite: str | None = None,
         encoder: Callable[[object], str] = json.dumps,
         decoder: Callable[[str], Any] = json.loads
     ) -> None:

--- a/aiohttp_session/redis_storage.py
+++ b/aiohttp_session/redis_storage.py
@@ -1,6 +1,7 @@
 import json
 import uuid
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 from aiohttp import web
 
@@ -32,12 +33,12 @@ class RedisStorage(AbstractStorage):
         redis_pool: "aioredis.Redis",
         *,
         cookie_name: str = "AIOHTTP_SESSION",
-        domain: Optional[str] = None,
-        max_age: Optional[int] = None,
+        domain: str | None = None,
+        max_age: int | None = None,
         path: str = "/",
-        secure: Optional[bool] = None,
+        secure: bool | None = None,
         httponly: bool = True,
-        samesite: Optional[str] = None,
+        samesite: str | None = None,
         key_factory: Callable[[], str] = lambda: uuid.uuid4().hex,
         encoder: Callable[[object], str] = json.dumps,
         decoder: Callable[[str], Any] = json.loads,

--- a/demo/flash_messages_example.py
+++ b/demo/flash_messages_example.py
@@ -1,5 +1,5 @@
 import base64
-from typing import List, NoReturn, cast
+from typing import NoReturn, cast
 
 from aiohttp import web
 from aiohttp.typedefs import Handler
@@ -13,8 +13,8 @@ def flash(request: web.Request, message: str) -> None:
     request.setdefault("flash_outgoing", []).append(message)
 
 
-def get_messages(request: web.Request) -> List[str]:
-    return cast(List[str], request.pop("flash_incoming"))
+def get_messages(request: web.Request) -> list[str]:
+    return cast(list[str], request.pop("flash_incoming"))
 
 
 @web.middleware

--- a/demo/login_required_example.py
+++ b/demo/login_required_example.py
@@ -1,6 +1,7 @@
 import base64
+from collections.abc import Awaitable, Callable
 from http import HTTPStatus
-from typing import Any, Awaitable, Callable
+from typing import Any
 
 from aiohttp import web
 from cryptography import fernet

--- a/demo/redis_storage.py
+++ b/demo/redis_storage.py
@@ -1,5 +1,5 @@
 import time
-from typing import AsyncIterator
+from collections.abc import AsyncIterator
 
 from aiohttp import web
 from redis import asyncio as aioredis

--- a/examples/postgres_storage.py
+++ b/examples/postgres_storage.py
@@ -1,6 +1,7 @@
 import json
 import uuid
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 import psycopg2.extras
 from aiohttp import web
@@ -17,10 +18,10 @@ class PgStorage(AbstractStorage):
         pg_pool: Pool,
         *,
         cookie_name: str = "AIOHTTP_SESSION",
-        domain: Optional[str] = None,
-        max_age: Optional[int] = None,
+        domain: str | None = None,
+        max_age: int | None = None,
         path: str = "/",
-        secure: Optional[bool] = None,
+        secure: bool | None = None,
         httponly: bool = True,
         key_factory: Callable[[], str] = lambda: uuid.uuid4().hex,
         encoder: Callable[[object], str] = psycopg2.extras.Json,

--- a/setup.py
+++ b/setup.py
@@ -35,12 +35,12 @@ setup(
     description=("sessions for aiohttp.web"),
     long_description="\n\n".join((read("README.rst"), read("CHANGES.txt"))),
     long_description_content_type="text/x-rst",
+    python_requires=">=3.10",
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Intended Audience :: Developers",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Internet :: WWW/HTTP",
         "Framework :: AsyncIO",
         "Framework :: aiohttp",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,8 @@ import socket
 import sys
 import time
 import uuid
-from typing import AsyncIterator, Iterator, TypedDict
+from collections.abc import AsyncIterator, Iterator
+from typing import TypedDict
 
 import aiomcache
 import pytest

--- a/tests/test_abstract_storage.py
+++ b/tests/test_abstract_storage.py
@@ -1,7 +1,7 @@
 import json
 import time
 from functools import partial
-from typing import Any, Dict, Optional
+from typing import Any
 from unittest import mock
 
 from aiohttp import web
@@ -14,7 +14,7 @@ from .typedefs import AiohttpClient
 
 
 def make_cookie(
-    client: TestClient[web.Request, web.Application], data: Dict[str, Any]
+    client: TestClient[web.Request, web.Application], data: dict[str, Any]
 ) -> None:
     session_data = {"session": data, "created": int(time.time())}
 
@@ -46,7 +46,7 @@ async def test_max_age_also_returns_expires(aiohttp_client: AiohttpClient) -> No
 
 
 async def test_max_age_session_reset(aiohttp_client: AiohttpClient) -> None:
-    async def handler(request: web.Request, n: Optional[str] = None) -> web.Response:
+    async def handler(request: web.Request, n: str | None = None) -> web.Response:
         session = await get_session(request)
         if n:
             session[n] = True

--- a/tests/test_cookie_storage.py
+++ b/tests/test_cookie_storage.py
@@ -1,7 +1,8 @@
 import json
 import time
+from collections.abc import MutableMapping
 from http.cookies import SimpleCookie
-from typing import Any, Dict, MutableMapping, cast
+from typing import Any, cast
 
 from aiohttp import web
 from aiohttp.test_utils import TestClient
@@ -18,7 +19,7 @@ from .typedefs import AiohttpClient
 
 
 def make_cookie(
-    client: TestClient[web.Request, web.Application], data: Dict[str, Any]
+    client: TestClient[web.Request, web.Application], data: dict[str, Any]
 ) -> None:
     session_data = {"session": data, "created": int(time.time())}
 

--- a/tests/test_encrypted_cookie_storage.py
+++ b/tests/test_encrypted_cookie_storage.py
@@ -2,7 +2,8 @@ import asyncio
 import base64
 import json
 import time
-from typing import Any, Dict, MutableMapping, Tuple, Union, cast
+from collections.abc import MutableMapping
+from typing import Any, cast
 
 import pytest
 from aiohttp import web
@@ -21,7 +22,7 @@ MAX_AGE = 1
 def make_cookie(
     client: TestClient[web.Request, web.Application],
     fernet: Fernet,
-    data: Dict[str, Any],
+    data: dict[str, Any],
 ) -> None:
     session_data = {"session": data, "created": int(time.time())}
 
@@ -32,7 +33,7 @@ def make_cookie(
 
 
 def create_app(
-    handler: Handler, key: Union[str, bytes, bytearray, Fernet]
+    handler: Handler, key: str | bytes | bytearray | Fernet
 ) -> web.Application:
     middleware = session_middleware(EncryptedCookieStorage(key))
     app = web.Application(middlewares=[middleware])
@@ -40,26 +41,26 @@ def create_app(
     return app
 
 
-def decrypt(fernet: Fernet, cookie_value: str) -> Dict[str, Any]:
+def decrypt(fernet: Fernet, cookie_value: str) -> dict[str, Any]:
     assert type(cookie_value) == str  # noqa: E721
     cookie_value = fernet.decrypt(cookie_value.encode("utf-8")).decode("utf-8")
-    return cast(Dict[str, Any], json.loads(cookie_value))
+    return cast(dict[str, Any], json.loads(cookie_value))
 
 
 @pytest.fixture
-def fernet_and_key() -> Tuple[Fernet, bytes]:
+def fernet_and_key() -> tuple[Fernet, bytes]:
     key = Fernet.generate_key()
     fernet = Fernet(key)
     return fernet, base64.urlsafe_b64decode(key)
 
 
 @pytest.fixture
-def fernet(fernet_and_key: Tuple[Fernet, bytes]) -> Fernet:
+def fernet(fernet_and_key: tuple[Fernet, bytes]) -> Fernet:
     return fernet_and_key[0]
 
 
 @pytest.fixture
-def key(fernet_and_key: Tuple[Fernet, bytes]) -> bytes:
+def key(fernet_and_key: tuple[Fernet, bytes]) -> bytes:
     return fernet_and_key[1]
 
 

--- a/tests/test_http_exception.py
+++ b/tests/test_http_exception.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 from aiohttp import web
 from aiohttp.typedefs import Handler
 
@@ -8,7 +6,7 @@ from aiohttp_session import SimpleCookieStorage, get_session, session_middleware
 from .typedefs import AiohttpClient
 
 
-def create_app(*handlers: Tuple[str, Handler]) -> web.Application:
+def create_app(*handlers: tuple[str, Handler]) -> web.Application:
     middleware = session_middleware(SimpleCookieStorage())
     app = web.Application(middlewares=[middleware])
     for url, handler in handlers:

--- a/tests/test_memcached_storage.py
+++ b/tests/test_memcached_storage.py
@@ -2,7 +2,8 @@ import asyncio
 import json
 import time
 import uuid
-from typing import Any, Callable, Dict, MutableMapping, Optional, cast
+from collections.abc import Callable, MutableMapping
+from typing import Any, cast
 
 import aiomcache
 from aiohttp import web
@@ -18,7 +19,7 @@ from .typedefs import AiohttpClient
 def create_app(
     handler: Handler,
     memcached: aiomcache.Client,
-    max_age: Optional[int] = None,
+    max_age: int | None = None,
     key_factory: Callable[[], str] = lambda: uuid.uuid4().hex,
 ) -> web.Application:
     middleware = session_middleware(
@@ -32,7 +33,7 @@ def create_app(
 async def make_cookie(
     client: TestClient[web.Request, web.Application],
     memcached: aiomcache.Client,
-    data: Dict[str, Any],
+    data: dict[str, Any],
 ) -> None:
     session_data = {"session": data, "created": int(time.time())}
     value = json.dumps(session_data)
@@ -53,14 +54,14 @@ async def make_cookie_with_bad_value(
 
 async def load_cookie(
     client: TestClient[web.Request, web.Application], memcached: aiomcache.Client
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     cookies = client.session.cookie_jar.filter_cookies(client.make_url("/"))
     key = cookies["AIOHTTP_SESSION"]
     storage_key = ("AIOHTTP_SESSION_" + key.value).encode("utf-8")
     encoded = await memcached.get(storage_key)
     assert encoded is not None
     s = encoded.decode("utf-8")
-    return cast(Dict[str, Any], json.loads(s))
+    return cast(dict[str, Any], json.loads(s))
 
 
 async def test_create_new_session(

--- a/tests/test_nacl_storage.py
+++ b/tests/test_nacl_storage.py
@@ -1,7 +1,8 @@
 import asyncio
 import json
 import time
-from typing import Any, Dict, MutableMapping, Optional, cast
+from collections.abc import MutableMapping
+from typing import Any, cast
 
 import nacl.secret
 import nacl.utils
@@ -25,7 +26,7 @@ def test_invalid_key() -> None:
 def make_cookie(
     client: TestClient[web.Request, web.Application],
     secretbox: nacl.secret.SecretBox,
-    data: Dict[str, Any],
+    data: dict[str, Any],
 ) -> None:
     session_data = {"session": data, "created": int(time.time())}
 
@@ -37,7 +38,7 @@ def make_cookie(
 
 
 def create_app(
-    handler: Handler, key: bytes, max_age: Optional[int] = None
+    handler: Handler, key: bytes, max_age: int | None = None
 ) -> web.Application:
     middleware = session_middleware(NaClCookieStorage(key, max_age=max_age))
     app = web.Application(middlewares=[middleware])

--- a/tests/test_path_domain.py
+++ b/tests/test_path_domain.py
@@ -1,7 +1,7 @@
 import json
 import time
 from http import cookies
-from typing import Any, Optional
+from typing import Any
 
 from aiohttp import web
 from aiohttp.test_utils import TestClient
@@ -15,8 +15,8 @@ from .typedefs import AiohttpClient
 def make_cookie(
     client: TestClient[web.Request, web.Application],
     data: Any,
-    path: Optional[str] = None,
-    domain: Optional[str] = None,
+    path: str | None = None,
+    domain: str | None = None,
 ) -> None:
     session_data = {"session": data, "created": int(time.time())}
     C = cookies.SimpleCookie()
@@ -28,7 +28,7 @@ def make_cookie(
 
 
 def create_app(
-    handler: Handler, path: Optional[str] = None, domain: Optional[str] = None
+    handler: Handler, path: str | None = None, domain: str | None = None
 ) -> web.Application:
     storage = SimpleCookieStorage(max_age=10, path="/anotherpath", domain="127.0.0.1")
     middleware = session_middleware(storage)

--- a/tests/test_redis_storage.py
+++ b/tests/test_redis_storage.py
@@ -4,7 +4,8 @@ import asyncio
 import json
 import time
 import uuid
-from typing import Any, Callable, MutableMapping, cast
+from collections.abc import Callable, MutableMapping
+from typing import Any, cast
 
 import pytest
 from aiohttp import web

--- a/tests/test_response_types.py
+++ b/tests/test_response_types.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import make_mocked_request
@@ -15,7 +13,7 @@ from aiohttp_session import (
 from .typedefs import AiohttpClient
 
 
-def create_app(*handlers: Tuple[str, Handler]) -> web.Application:
+def create_app(*handlers: tuple[str, Handler]) -> web.Application:
     middleware = session_middleware(SimpleCookieStorage())
     app = web.Application(middlewares=[middleware])
     for url, handler in handlers:

--- a/tests/test_session_dict.py
+++ b/tests/test_session_dict.py
@@ -1,5 +1,6 @@
 import time
-from typing import Any, MutableMapping, cast
+from collections.abc import MutableMapping
+from typing import Any, cast
 
 import pytest
 

--- a/tests/typedefs.py
+++ b/tests/typedefs.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Callable
+from collections.abc import Awaitable, Callable
 
 from aiohttp import web
 from aiohttp.test_utils import TestClient


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add support for Python 3.14, released in October 2025.

Drop support for Python 3.9, reached EOL the same month.

This matches the latest aiohttp: https://pypi.org/project/aiohttp/3.14.0/

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

n/a

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
