### PR TITLE
Stop resetting Session.created on mutation

### DIFF
--- a/CHANGES/981.bugfix.rst
+++ b/CHANGES/981.bugfix.rst
@@ -1,0 +1,5 @@
+Stopped resetting :py:attr:`Session.created` to the current time whenever the
+session was mutated (via ``__setitem__``/``__delitem__``). ``created`` now
+reflects the session's actual creation time, as documented, while a new
+internal ``last_visit`` timestamp is used to preserve the existing idle
+``max_age`` timeout behavior -- by :user:`pctablet505`.

--- a/aiohttp_session/__init__.py
+++ b/aiohttp_session/__init__.py
@@ -24,6 +24,7 @@ class _CookieParams(TypedDict, total=False):
 
 class SessionData(TypedDict, total=False):
     created: int
+    last_visit: float
     session: dict[str, Any]
 
 
@@ -45,15 +46,21 @@ class Session(MutableMapping[str, Any]):
         self._new = new if data != {} else True
         self._max_age = max_age
         created = data.get("created", None) if data else None
+        last_visit = data.get("last_visit", None) if data else None
         session_data = data.get("session", None) if data else None
-        now = int(time.time())
-        age = now - created if created else now
+        now = time.time()
+        # `last_visit` tracks the most recent activity and is used to
+        # implement an idle timeout. Older, existing session data may not
+        # have `last_visit`, so fall back to `created` for compatibility.
+        last_active = last_visit if last_visit is not None else created
+        age = now - last_active if last_active else now
         if max_age is not None and age > max_age:
             session_data = None
         if self._new or created is None:
-            self._created = now
+            self._created = int(now)
         else:
             self._created = created
+        self._last_visit = last_active if last_active is not None else now
 
         if session_data is not None:
             self._mapping.update(session_data)
@@ -119,12 +126,12 @@ class Session(MutableMapping[str, Any]):
     def __setitem__(self, key: str, value: Any) -> None:
         self._mapping[key] = value
         self._changed = True
-        self._created = int(time.time())
+        self._last_visit = time.time()
 
     def __delitem__(self, key: str) -> None:
         del self._mapping[key]
         self._changed = True
-        self._created = int(time.time())
+        self._last_visit = time.time()
 
 
 SESSION_KEY = "aiohttp_session"
@@ -250,7 +257,11 @@ class AbstractStorage(metaclass=abc.ABCMeta):
         if session.empty:
             return {}
 
-        return {"created": session.created, "session": session._mapping}
+        return {
+            "created": session.created,
+            "last_visit": session._last_visit,
+            "session": session._mapping,
+        }
 
     async def new_session(self) -> Session:
         return Session(None, data=None, new=True, max_age=self.max_age)

--- a/tests/test_session_dict.py
+++ b/tests/test_session_dict.py
@@ -1,6 +1,7 @@
 import time
 from collections.abc import MutableMapping
 from typing import Any, cast
+from unittest import mock
 
 import pytest
 
@@ -140,18 +141,26 @@ def test_operations() -> None:
 
 
 def test_created_not_modified_on_mutation() -> None:
-    s = Session("test_identity", data=None, new=True)
-    created = s.created
+    # Advance the clock between construction and each mutation so that a
+    # regression (created being reset to the current time on mutation)
+    # can't coincide with the original value within the same second.
+    with mock.patch("time.time") as m_clock:
+        m_clock.return_value = 0.0
+        s = Session("test_identity", data=None, new=True)
+        created = s.created
 
-    s["foo"] = "bar"
-    assert s.created == created
+        m_clock.return_value = 100.0
+        s["foo"] = "bar"
+        assert s.created == created
 
-    del s["foo"]
-    assert s.created == created
+        m_clock.return_value = 200.0
+        del s["foo"]
+        assert s.created == created
 
-    s["foo"] = "bar"
-    s.invalidate()
-    assert s.created == created
+        m_clock.return_value = 300.0
+        s["foo"] = "bar"
+        s.invalidate()
+        assert s.created == created
 
 
 def test_created_preserved_across_reload() -> None:

--- a/tests/test_session_dict.py
+++ b/tests/test_session_dict.py
@@ -139,6 +139,31 @@ def test_operations() -> None:
     assert "key" not in s
 
 
+def test_created_not_modified_on_mutation() -> None:
+    s = Session("test_identity", data=None, new=True)
+    created = s.created
+
+    s["foo"] = "bar"
+    assert s.created == created
+
+    del s["foo"]
+    assert s.created == created
+
+    s["foo"] = "bar"
+    s.invalidate()
+    assert s.created == created
+
+
+def test_created_preserved_across_reload() -> None:
+    created = int(time.time()) - 1000
+    session_data: SessionData = {"session": {"key": 123}, "created": created}
+    s = Session("test_identity", data=session_data, new=False)
+    assert s.created == created
+
+    s["key"] = 456
+    assert s.created == created
+
+
 def test_change() -> None:
     created = int(time.time())
     s = Session(


### PR DESCRIPTION
## What do these changes do?

`Session.created` is documented as the timestamp of the session's
first access, but `__setitem__`/`__delitem__` were bumping it on
every change, so in practice it reflected the last write instead.

That behavior was added in #671 to fix an idle-timeout bug (`max_age`
is treated as an inactivity timeout, so an actively used session
shouldn't expire). Simply reverting #671 would bring that expiry bug
back, so instead this tracks last-activity time separately as
`last_visit` and uses that for the expiry check, leaving `created`
untouched after the session is first created. Sessions serialized
before this change won't have `last_visit`, so the expiry check falls
back to `created` for them, same as before.

## Are there changes in behavior for the user?

`Session.created` now stays fixed for the lifetime of a session,
matching the documentation. The idle-timeout behavior for `max_age`
is unchanged.

## Related issue number

Fixes #981

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes